### PR TITLE
Feature/transaction smartbridge tooltip

### DIFF
--- a/src/app/pages/address/address-transactions/address-transactions.component.html
+++ b/src/app/pages/address/address-transactions/address-transactions.component.html
@@ -12,8 +12,9 @@
     </thead>
     <tbody>
         <tr *ngFor="let item of items">
-            <td class="ark-transaction ellipsis width-15" [ngClass]="{'ark-transaction': item.vendorField}">
+            <td class="ark-transaction ellipsis width-15 ark-tooltip-wrap" [ngClass]="{'ark-transaction': item.vendorField}">
                 <a href="#" (click)="goToTransaction($event, item.id)">{{item.id | overflowText}}</a>
+                <span class="ark-tooltip" *ngIf="item.vendorField">{{ item.vendorField }}</span>
             </td>
             <td class="ellipsis width-15">{{item.timestamp | localDate | amDateFormat:'YYYY-MM-DD HH:mm:ss'}}</td>
             <td class="ark-blue-text ellipsis width-15">

--- a/src/app/pages/block/block.component.html
+++ b/src/app/pages/block/block.component.html
@@ -72,8 +72,9 @@
                     </thead>
                     <tbody *ngIf="transactions && transactions.length">
                         <tr *ngFor="let transaction of transactions">
-                            <td class="ark-transaction ellipsis width-15">
+                            <td class="ark-transaction ellipsis width-15 ark-tooltip-wrap">
                                 <a href="#" (click)="goToTransaction($event, transaction.id)">{{transaction.id | overflowText}}</a>
+                                <span class="ark-tooltip" *ngIf="transaction.vendorField">{{ transaction.vendorField }}</span>
                             </td>
                             <td class="ellipsis width-15">{{transaction.timestamp | localDate | amDateFormat:'YYYY-MM-DD HH:mm:ss'}}</td>
                             <td class="ark-blue-text ellipsis width-15">

--- a/src/app/pages/block/block.component.html
+++ b/src/app/pages/block/block.component.html
@@ -72,7 +72,7 @@
                     </thead>
                     <tbody *ngIf="transactions && transactions.length">
                         <tr *ngFor="let transaction of transactions">
-                            <td class="ark-transaction ellipsis width-15 ark-tooltip-wrap">
+                            <td class="ark-transaction ellipsis width-15 ark-tooltip-wrap" [ngClass]="{'ark-transaction': transaction.vendorField}">
                                 <a href="#" (click)="goToTransaction($event, transaction.id)">{{transaction.id | overflowText}}</a>
                                 <span class="ark-tooltip" *ngIf="transaction.vendorField">{{ transaction.vendorField }}</span>
                             </td>

--- a/src/app/pages/explorer/explorer.component.html
+++ b/src/app/pages/explorer/explorer.component.html
@@ -25,7 +25,9 @@
         </thead>
         <tbody>
             <tr *ngFor="let item of transactions">
-                <td class="ellipsis width-15" [ngClass]="{'ark-transaction': item.vendorField}"><a href="#" (click)="goToTransaction($event, item.id)">{{item.id | overflowText}}</a></td>
+                <td class="ellipsis width-15 ark-tooltip-wrap" [ngClass]="{'ark-transaction': item.vendorField}"><a href="#" (click)="goToTransaction($event, item.id)">{{item.id | overflowText}}</a>
+                    <span class="ark-tooltip" *ngIf="item.vendorField">{{ item.vendorField }}</span>
+                </td>
                 <td class="ellipsis width-15">{{item.timestamp | localDate | amDateFormat:'YYYY-MM-DD HH:mm:ss'}}</td>
                 <td class="ellipsis width-15"><a href="#" (click)="goToAddress($event, item.senderId)"><span *ngIf="item.senderDelegate">{{item.senderDelegate.username}}</span> <span *ngIf="!item.senderDelegate">{{item.senderId | overflowText}}</span></a></td>
                 <td class="ellipsis width-15"><a href="#" (click)="goToAddress($event, item.recipientId)">{{item.recipientId | overflowText}}</a></td>

--- a/src/app/pages/transaction/transaction.component.html
+++ b/src/app/pages/transaction/transaction.component.html
@@ -68,8 +68,9 @@
                     </thead>
                     <tbody>
                         <tr>
-                            <td class="ellipsis width-15" [ngClass]="{'ark-transaction': transaction.vendorField}">
+                            <td class="ellipsis width-15 ark-tooltip-wrap" [ngClass]="{'ark-transaction': transaction.vendorField}">
                                 <a href="#" (click)="goToTransaction($event, transaction.id)">{{transaction.id | overflowText}}</a>
+                                <span class="ark-tooltip" *ngIf="transaction.vendorField">{{ transaction.vendorField }}</span>
                             </td>
                             <td class="ellipsis width-15">{{transaction.timestamp | localDate | amDateFormat:'YYYY-MM-DD HH:mm:ss'}}</td>
                             <td class="ark-blue-text ellipsis width-15">


### PR DESCRIPTION
Show a tooltip containing the Smartbridge text/ Vendor Field when hovering over the "Transaction ID" field of a transaction.

Also, fixed a bug where every transaction on the page for a block (https://explorer.ark.io/block/BLOCK-NUM) had the tag icon next to the Transaction ID, meaning it's Vendor Field contained text. However, the tag was showing even if the Vendor Field was empty.