### PR TITLE
Fix mobile menu closing randomly because the currency gets set every …

### DIFF
--- a/src/app/components/header/currency-dropdown/currency-dropdown.component.ts
+++ b/src/app/components/header/currency-dropdown/currency-dropdown.component.ts
@@ -29,10 +29,12 @@ export class CurrencyDropdownComponent implements OnInit {
     setTimeout(_ => {
       if(this.currency.length > 1) {
         let cur = localStorage.getItem('currency') || initCurrency.name;
-        this.setCurrency(cur);
+        if (cur != this.currentCurrency) {
+          this.setCurrency(cur);
+        }
       }
     });
-    
+
   }
 
   get rates(): any {


### PR DESCRIPTION
…few seconds.

The mobile menu would close every few seconds because the currency would be set every few seconds when the tickers update. The mobile menu would close, thinking that the user had selected a currency, even if no input has been given. This has been fixed by only auto setting the currency if it differs from the current currency (which should only happen once after loading).