### PR TITLE
Currency formatter (rounding, commas, and trimming insignificant 0's)

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -32,7 +32,7 @@ import { DelegateMonitorComponent } from './pages/delegate-monitor/delegate-moni
 import { ToolsDropdownComponent } from './components/header/tools-dropdown/tools-dropdown.component';
 import { BalanceFooterComponent } from './pages/address/balance-footer/balance-footer.component';
 
-import { DatePipe, OverflowTextPipe } from './shared/pipes/general.pipe';
+import { DatePipe, OverflowTextPipe, CurrencyFormatPipe } from './shared/pipes/general.pipe';
 import { TopAccountsComponent } from './pages/top-accounts/top-accounts.component';
 import { DelegatesComponent } from './pages/delegate-monitor/delegates/delegates.component';
 import { ScrollTopComponent } from './components/scroll-top/scroll-top.component';
@@ -65,7 +65,8 @@ export function HttpLoaderFactory(httpClient: HttpClient) {
     TopAccountsComponent,
     DelegatesComponent,
     ScrollTopComponent,
-    ToggleBackgroundComponent
+    ToggleBackgroundComponent,
+    CurrencyFormatPipe
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -36,27 +36,27 @@
                 </span>
                 <span class="ark-item-index">
                     <span class="ark-index-title"> ARK/BTC:</span>
-                    <span class="ark-index-data">{{headerBTC | number: '1.8-8'}}</span>
+                    <span class="ark-index-data">{{headerBTC | currencyFormat: 'BTC'}}</span>
                 </span>
             </div>
             <div class="ark-data-item">
                 <span class="ark-item-index">
                     <span class="ark-index-title"> ARK/USD:</span>
-                    <span class="ark-index-data">{{headerUSD  | number: '1.0-2'}}</span>
+                    <span class="ark-index-data">{{headerUSD | currencyFormat: 'USD'}}</span>
                 </span>
                 <span class="ark-item-index">
                     <span class="ark-index-title"> ARK/EUR:</span>
-                    <span class="ark-index-data">{{headerEUR  | number: '1.0-2'}}</span>
+                    <span class="ark-index-data">{{headerEUR | currencyFormat: 'EUR'}}</span>
                 </span>
             </div>
             <div class="ark-data-item">
                 <span class="ark-item-index">
                     <span class="ark-index-title"> ARK/GBP:</span>
-                    <span class="ark-index-data">{{headerGBP  | number: '1.0-2'}}</span>
+                    <span class="ark-index-data">{{headerGBP | currencyFormat: 'GBP'}}</span>
                 </span>
                 <span class="ark-item-index">
                     <span class="ark-index-title"> ARK/CNY:</span>
-                    <span class="ark-index-data">{{headerCNY  | number: '1.0-2'}}</span>
+                    <span class="ark-index-data">{{headerCNY | currencyFormat: 'CNY'}}</span>
                 </span>
             </div>
         </div>

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -22,7 +22,7 @@
             <div class="ark-data-item">
                 <span class="ark-item-index">
                     <span class="ark-index-title"> {{ 'GENERAL.INFO.HEIGHT' | translate}}:</span>
-                    <span class="ark-index-data">{{headerHeight}}</span>
+                    <span class="ark-index-data">{{headerHeight | number: 0}}</span>
                 </span>
                 <span class="ark-item-index">
                     <span class="ark-index-title"> {{ 'GENERAL.INFO.NETHASH' | translate}}:</span>
@@ -32,7 +32,7 @@
             <div class="ark-data-item">
                 <span class="ark-item-index">
                     <span class="ark-index-title"> {{ 'GENERAL.INFO.SUPPLY' | translate}}:</span>
-                    <span class="ark-index-data">{{headerSupply}}</span>
+                    <span class="ark-index-data">{{headerSupply | number: 0}}</span>
                 </span>
                 <span class="ark-item-index">
                     <span class="ark-index-title"> ARK/BTC:</span>

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -66,10 +66,10 @@ export class HeaderComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this._currencyService.getCNYprice().subscribe(res => {
-      this.headerCNY = res.ticker.price;
+      this.headerCNY = Number(res.ticker.price);
     });
     this._currencyService.getGBPprice().subscribe(res => {
-      this.headerGBP = res.ticker.price;
+      this.headerGBP = Number(res.ticker.price);
     });
     this.getExtraRates();
   }
@@ -85,10 +85,10 @@ export class HeaderComponent implements OnInit, OnDestroy {
   getExtraRates() {
     this._timer = setInterval(() => {
       this._currencyService.getCNYprice().subscribe(res => {
-        this.headerCNY = res.ticker.price;
+        this.headerCNY = Number(res.ticker.price);
       });
       this._currencyService.getGBPprice().subscribe(res => {
-        this.headerGBP = res.ticker.price;
+        this.headerGBP = Number(res.ticker.price);
       });
     }, 5*60000);
   }

--- a/src/app/pages/activity-graph/activity-graph.component.html
+++ b/src/app/pages/activity-graph/activity-graph.component.html
@@ -42,7 +42,7 @@
                     </li>
                     <li class="ark-flex ark-flex-between">
                         <div class="title">{{ 'ACTIVITY_GRAPH.STATISTICS.VOLUME' | translate}}</div>
-                        <div class="count">{{statistic.volume * currencyValue}} <span class="opacity">{{currencyName}}</span></div>
+                        <div class="count">{{statistic.volume * currencyValue | currencyFormat}} <span class="opacity">{{currencyName}}</span></div>
                     </li>
                     <li class="ark-flex ark-flex-between">
                         <div class="title">{{ 'ACTIVITY_GRAPH.STATISTICS.BLOCKS' | translate}}</div>

--- a/src/app/pages/address/address-transactions/address-transactions.component.html
+++ b/src/app/pages/address/address-transactions/address-transactions.component.html
@@ -29,9 +29,9 @@
                 <span *ngIf="item.asset && item.asset.delegate">{{ 'TRANSACTION.ASSET.DELEGATE' | translate }}</span>
             </td>
             <td class="ellipsis width-15" [ngClass]="{'ark-amount-plus': item.recipientId === id && item.recipientId !== item.senderId && !(item.asset && item.asset.votes || item.asset && item.asset.signature || item.asset && item.asset.delegate), 'ark-amount-minus': item.senderId === id && item.recipientId !== item.senderId && !(item.asset && item.asset.votes || item.asset && item.asset.signature || item.asset && item.asset.delegate)}">
-                {{(item.amount / 100000000)*curValue | number: '1.2-2'}} {{curName}}
+                {{(item.amount / 100000000)*curValue | currencyFormat}} {{curName}}
             </td>
-            <td class="ellipsis width-10">{{(item.fee / 100000000)*curValue | number: '1.2-2'}} {{curName}}</td>
+            <td class="ellipsis width-10">{{(item.fee / 100000000)*curValue | currencyFormat}} {{curName}}</td>
             <td class="ellipsis width-15 ark-tooltip-wrap">
                 <span *ngIf="item.confirmations <= 50">{{item.confirmations}}</span>
                 <span *ngIf="item.confirmations > 50">{{ 'GENERAL.WELL_CONFIRMED' | translate }}</span>

--- a/src/app/pages/address/address.component.html
+++ b/src/app/pages/address/address.component.html
@@ -84,12 +84,12 @@
             <div class="ark-address-summary voters-container" style="display: block;" *ngIf="!openVoters" #voters>
                 <div class="voters-button" (click)="showBlock()"></div>
                 <span class="voters-address" *ngFor="let item of addressItem.voters; let i = index;">
-                    <a href="#" (click)="goToAddress($event, item.address)" *ngIf="i < votersNumber">{{item.address}} ({{(item.balance / 100000000) | currencyFormat: 'ARK'}} ARK)</a>
+                    <a href="#" (click)="goToAddress($event, item.address)" *ngIf="i < votersNumber">{{item.address}} ({{(item.balance / 100000000)*currencyValue | currencyFormat: currencyName}} {{currencyName}})</a>
                 </span>
             </div>
             <div class="ark-address-summary voters-container open" style="display: block;" *ngIf="openVoters" #voters>
                 <div class="voters-button" (click)="showBlock()"></div>
-                <span class="voters-address" *ngFor="let item of addressItem.voters"><a href="#" (click)="goToAddress($event, item.address)">{{item.address}} ({{(item.balance / 100000000) | currencyFormat: 'ARK'}} ARK)</a> </span>
+                <span class="voters-address" *ngFor="let item of addressItem.voters"><a href="#" (click)="goToAddress($event, item.address)">{{item.address}} ({{(item.balance / 100000000)*currencyValue | currencyFormat: currencyName}} {{currencyName}})</a> </span>
             </div>
         </div>
         <!-- voters blocks -->

--- a/src/app/pages/address/address.component.html
+++ b/src/app/pages/address/address.component.html
@@ -23,7 +23,7 @@
                 </div>
                 <div class="ark-summary-item ark-flex-between" *ngIf="addressItem.balance" #balance>
                     <span class="ark-summary-title">{{ 'GENERAL.INFO.TOTAL_BALANCE' | translate }}</span>
-                    <span class="ark-summary-data">{{(addressItem.balance / 100000000)*currencyValue | number: '1.2-2'}} <span class="opacity">{{currencyName}}</span></span>
+                    <span class="ark-summary-data">{{(addressItem.balance / 100000000)*currencyValue | currencyFormat}} <span class="opacity">{{currencyName}}</span></span>
                 </div>
                 <div class="ark-summary-item ark-flex-between">
                     <span class="ark-summary-title">{{ 'GENERAL.INFO.TRANSACTIONS' | translate }}</span>
@@ -58,7 +58,7 @@
                     </div>
                     <div class="ark-summary-item ark-flex-between" *ngIf="addressItem.delegate.forged">
                         <span class="ark-summary-title">{{ 'GENERAL.INFO.FORGED' | translate }}</span>
-                        <span class="ark-summary-data">{{(+addressItem.delegate.forged/100000000)*currencyValue | number: '1.2-2'}} <span class="opacity">{{currencyName}}</span></span>
+                        <span class="ark-summary-data">{{(+addressItem.delegate.forged/100000000)*currencyValue | currencyFormat}} <span class="opacity">{{currencyName}}</span></span>
                     </div>
                     <div class="ark-summary-item ark-flex-between" *ngIf="addressItem.delegate.producedblocks">
                         <span class="ark-summary-title">{{ 'GENERAL.INFO.BLOCKS' | translate }}</span>
@@ -84,12 +84,12 @@
             <div class="ark-address-summary voters-container" style="display: block;" *ngIf="!openVoters" #voters>
                 <div class="voters-button" (click)="showBlock()"></div>
                 <span class="voters-address" *ngFor="let item of addressItem.voters; let i = index;">
-                    <a href="#" (click)="goToAddress($event, item.address)" *ngIf="i < votersNumber">{{item.address}} ({{(item.balance / 100000000) | number: '1.2-2'}} ARK)</a>
+                    <a href="#" (click)="goToAddress($event, item.address)" *ngIf="i < votersNumber">{{item.address}} ({{(item.balance / 100000000) | currencyFormat: 'ARK'}} ARK)</a>
                 </span>
             </div>
             <div class="ark-address-summary voters-container open" style="display: block;" *ngIf="openVoters" #voters>
                 <div class="voters-button" (click)="showBlock()"></div>
-                <span class="voters-address" *ngFor="let item of addressItem.voters"><a href="#" (click)="goToAddress($event, item.address)">{{item.address}} ({{(item.balance / 100000000) | number: '1.2-2'}} ARK)</a> </span>
+                <span class="voters-address" *ngFor="let item of addressItem.voters"><a href="#" (click)="goToAddress($event, item.address)">{{item.address}} ({{(item.balance / 100000000) | currencyFormat: 'ARK'}} ARK)</a> </span>
             </div>
         </div>
         <!-- voters blocks -->

--- a/src/app/pages/address/balance-footer/balance-footer.component.html
+++ b/src/app/pages/address/balance-footer/balance-footer.component.html
@@ -1,6 +1,6 @@
 <div class="ark-balance-footer" *ngIf="show">
     <div class="ark-wrap ark-flex-center ark-flex-between">
         <p class="ark-balance-address">{{address}}</p>
-        <p class="ark-balance-amount">{{ 'GENERAL.INFO.FINAL_BALANCE' | translate}} {{(balance / 100000000)*curVal | number: '1.2-2'}} {{curName}}</p>
+        <p class="ark-balance-amount">{{ 'GENERAL.INFO.FINAL_BALANCE' | translate}} {{(balance / 100000000)*curVal | currencyFormat}} {{curName}}</p>
     </div>
 </div>

--- a/src/app/pages/block-list/block-list.component.html
+++ b/src/app/pages/block-list/block-list.component.html
@@ -19,8 +19,8 @@
                 <td class="ellipsis width-15">{{item.timestamp | localDate | amDateFormat:'YYYY-MM-DD HH:mm:ss'}}</td>
                 <td class="ellipsis width-15">{{item.transactionsCount}}</td>
                 <td class="ellipsis width-15"><a href="#" (click)="goToAddress($event, item.delegate.address)">{{item.delegate.username}}</a></td>
-                <td class="ellipsis width-15">{{(item.totalAmount/100000000)*currencyValue | number: '1.2-2'}}</td>
-                <td class="ellipsis width-15">{{(item.totalForged/100000000)*currencyValue | number: '1.0-2'}}</td>
+                <td class="ellipsis width-15">{{(item.totalAmount/100000000)*currencyValue | currencyFormat}}</td>
+                <td class="ellipsis width-15">{{(item.totalForged/100000000)*currencyValue | currencyFormat}}</td>
             </tr>
         </tbody>
     </table>

--- a/src/app/pages/block/block.component.html
+++ b/src/app/pages/block/block.component.html
@@ -27,19 +27,19 @@
                 </div>
                 <div class="ark-summary-item ark-flex-between ark-flex-center">
                     <span class="ark-summary-title">{{ 'GENERAL.INFO.REWARD' | translate }}</span>
-                    <div class="ark-summary-data">{{(block.reward / 100000000)*currencyValue | number: '1.0-2'}} <span class="opacity">{{currencyName}}</span></div>
+                    <div class="ark-summary-data">{{(block.reward / 100000000)*currencyValue | currencyFormat}} <span class="opacity">{{currencyName}}</span></div>
                 </div>
                 <div class="ark-summary-item ark-flex-between ark-flex-center">
                     <span class="ark-summary-title">{{ 'GENERAL.INFO.TOTAL_FEE' | translate }}</span>
-                    <div class="ark-summary-data">{{(block.totalFee / 100000000)*currencyValue | number: '1.1-2'}} <span class="opacity">{{currencyName}}</span></div>
+                    <div class="ark-summary-data">{{(block.totalFee / 100000000)*currencyValue | currencyFormat}} <span class="opacity">{{currencyName}}</span></div>
                 </div>
                 <div class="ark-summary-item ark-flex-between ark-flex-center">
                     <span class="ark-summary-title">{{ 'GENERAL.INFO.TOTAL_FORGED' | translate }}</span>
-                    <div class="ark-summary-data">{{(block.totalForged / 100000000)*currencyValue | number: '1.1-2'}} <span class="opacity">{{currencyName}}</span></div>
+                    <div class="ark-summary-data">{{(block.totalForged / 100000000)*currencyValue | currencyFormat}} <span class="opacity">{{currencyName}}</span></div>
                 </div>
                 <div class="ark-summary-item ark-flex-between ark-flex-center">
                     <span class="ark-summary-title">{{ 'GENERAL.INFO.TOTAL_AMOUNT' | translate }}</span>
-                    <div class="ark-summary-data">{{(block.totalAmount / 100000000)*currencyValue | number: '1.2-2'}} <span class="opacity">{{currencyName}}</span></div>
+                    <div class="ark-summary-data">{{(block.totalAmount / 100000000)*currencyValue | currencyFormat}} <span class="opacity">{{currencyName}}</span></div>
                 </div>
                 <div class="ark-summary-item ark-flex-between ark-flex-center">
                     <span class="ark-summary-title">{{ 'GENERAL.INFO.TIMESTAMP' | translate }}</span>
@@ -88,8 +88,8 @@
                                 <span *ngIf="transaction.asset && transaction.asset.signature">{{ 'TRANSACTION.ASSET.SIGNATURE' | translate }}</span>
                                 <span *ngIf="transaction.asset && transaction.asset.delegate">{{ 'TRANSACTION.ASSET.DELEGATE' | translate }}</span>
                             </td>
-                            <td class="ark-amount ellipsis width-15">{{(transaction.amount / 100000000)*currencyValue | number: '1.2-2'}} {{currencyName}}</td>
-                            <td class="ellipsis width-10">{{(transaction.fee / 100000000)*currencyValue | number: '1.1-1'}} {{currencyName}}</td>
+                            <td class="ark-amount ellipsis width-15">{{(transaction.amount / 100000000)*currencyValue | currencyFormat}} {{currencyName}}</td>
+                            <td class="ellipsis width-10">{{(transaction.fee / 100000000)*currencyValue | currencyFormat}} {{currencyName}}</td>
                             <td class="ellipsis width-15 ark-tooltip-wrap">
                                 <span *ngIf="transaction.confirmations <= 50">{{transaction.confirmations}}</span>
                                 <span *ngIf="transaction.confirmations > 50">{{ 'GENERAL.WELL_CONFIRMED' | translate }}</span>

--- a/src/app/pages/delegate-monitor/delegate-monitor.component.html
+++ b/src/app/pages/delegate-monitor/delegate-monitor.component.html
@@ -29,7 +29,7 @@
                     <span *ngIf="!monitorData">N/A</span>
                 </div>
                 <div class="ark-info-item">
-                    <span *ngIf="monitorData && monitorData.lastBlock">{{(+monitorData.lastBlock.block.totalForged/100000000)*currencyValue | number: '1.0-2'}}</span>
+                    <span *ngIf="monitorData && monitorData.lastBlock">{{(+monitorData.lastBlock.block.totalForged/100000000)*currencyValue | currencyFormat}}</span>
                     <span *ngIf="!monitorData">0</span> {{currencyName}} {{ 'DELEGATE_MONITOR.MONITOR.FORGED_FROM' | translate}}
                     <span *ngIf="monitorData && monitorData.lastBlock">{{monitorData.lastBlock.block.numberOfTransactions}}</span>
                     <span *ngIf="!monitorData">0</span> {{ 'DELEGATE_MONITOR.MONITOR.TRANSACTIONS' | translate}}
@@ -52,7 +52,7 @@
             </li>
             <li>
                 <div class="ark-title">{{ 'GENERAL.INFO.TOTAL_FORGED' | translate }} <span class="opacity">({{currencyName}})</span></div>
-                <div class="ark-count">{{(totalForged/100000000)*currencyValue | number: '1.2-2'}}</div>
+                <div class="ark-count">{{(totalForged/100000000)*currencyValue | currencyFormat}}</div>
                 <div class="ark-info-item">{{ 'GENERAL.BETWEEN' | translate }} <span *ngIf="monitorData && monitorData.active">{{monitorData.active.delegates.length}}</span><span *ngIf="!monitorData">0</span> {{ 'DELEGATE_MONITOR.MONITOR.ACTIVE' | translate }}</div>
                 <div class="ark-gradient-border magenta-gradient"></div>
             </li>
@@ -63,7 +63,7 @@
                     <span *ngIf="!bestForger">N/A</span>
                 </div>
                 <div class="ark-info-item phrase-wrap">
-                    <span *ngIf="bestForger">{{(bestForger.forged/100000000)*currencyValue}}</span>
+                    <span *ngIf="bestForger">{{(bestForger.forged/100000000)*currencyValue | currencyFormat}}</span>
                     <span *ngIf="!bestForger">0</span> {{currencyName}} {{ 'DELEGATE_MONITOR.MONITOR.SINCE_REGISTRATION' | translate }}
                 </div>
                 <div class="ark-gradient-border darkblue-gradient"></div>
@@ -95,7 +95,7 @@
             <li>
                 <div class="ark-title">{{ 'GENERAL.INFO.TOTAL_FORGED' | translate }} ({{currencyName}})</div>
                 <div class="ark-count">
-                    <span *ngIf="supply">{{(+supply/100000000 - 125000000)*currencyValue | number: '1.2-2'}}</span>
+                    <span *ngIf="supply">{{(+supply/100000000 - 125000000)*currencyValue | currencyFormat}}</span>
                     <span *ngIf="!supply">0.00</span>
                 </div>
                 <div class="ark-info-item">{{ 'DELEGATE_MONITOR.MONITOR.FROM_START' | translate }}</div>

--- a/src/app/pages/delegate-monitor/delegates/delegates.component.html
+++ b/src/app/pages/delegate-monitor/delegates/delegates.component.html
@@ -16,7 +16,7 @@
             <td class="ellipsis width-15">{{item.rate}}</td>
             <td class="ellipsis width-15"><a href="#" (click)="goToAddress($event, item.address)">{{item.username}}</a></td>
             <td class="ellipsis width-20">{{item.address}}</td>
-            <td class="ellipsis width-15" *ngIf="active">{{(item.forged/100000000)*curValue | number: '1.2-2'}} <span class="opacity">{{curName}}</span></td>
+            <td class="ellipsis width-15" *ngIf="active">{{(item.forged/100000000)*curValue | currencyFormat}} <span class="opacity">{{curName}}</span></td>
             <td class="ellipsis width-15" *ngIf="active">{{item.forgingTime | amDuration:'seconds'}}</td>
             <td class="ellipsis width-15 ark-show-tooltip ark-status-td" *ngIf="active" [ngClass]="{
                 'active': item.forgingStatus.code === 0,

--- a/src/app/pages/explorer/explorer.component.html
+++ b/src/app/pages/explorer/explorer.component.html
@@ -32,8 +32,8 @@
                 <td class="ellipsis width-15"><a href="#" (click)="goToAddress($event, item.senderId)"><span *ngIf="item.senderDelegate">{{item.senderDelegate.username}}</span> <span *ngIf="!item.senderDelegate">{{item.senderId | overflowText}}</span></a></td>
                 <td class="ellipsis width-15"><a href="#" (click)="goToAddress($event, item.recipientId)">{{item.recipientId | overflowText}}</a></td>
                 <td class="ellipsis width-20">{{item.vendorField || ''}}</td>
-                <td class="ellipsis width-15">{{(+item.amount/100000000)*currencyRate | number: '1.2-2'}}</td>
-                <td class="ellipsis width-10">{{(+item.fee/100000000)*currencyRate | number: '1.1'}}</td>
+                <td class="ellipsis width-15">{{(+item.amount/100000000)*currencyRate | currencyFormat}}</td>
+                <td class="ellipsis width-10">{{(+item.fee/100000000)*currencyRate | currencyFormat}}</td>
             </tr>
         </tbody>
     </table>
@@ -61,8 +61,8 @@
                 <td class="ellipsis width-15">{{item.timestamp | localDate | amDateFormat:'YYYY-MM-DD HH:mm:ss'}}</td>
                 <td class="ellipsis width-10">{{item.transactionsCount}}</td>
                 <td class="ellipsis width-15"><a href="#" (click)="goToAddress($event, item.generator)">{{item.delegate.username}}</a></td>
-                <td class="ellipsis width-15">{{(+item.totalAmount/100000000)*currencyRate | number: '1.2-2'}}</td>
-                <td class="ellipsis width-15">{{(+item.totalForged/100000000)*currencyRate | number: '1.1'}}</td>
+                <td class="ellipsis width-15">{{(+item.totalAmount/100000000)*currencyRate | currencyFormat}}</td>
+                <td class="ellipsis width-15">{{(+item.totalForged/100000000)*currencyRate | currencyFormat}}</td>
             </tr>
         </tbody>
     </table>

--- a/src/app/pages/top-accounts/top-accounts.component.html
+++ b/src/app/pages/top-accounts/top-accounts.component.html
@@ -14,7 +14,7 @@
             <tr *ngFor="let item of accounts; let i = index;">
                 <td class="ellipsis width-15">{{i + 1}}</td>
                 <td class="ellipsis width-15"><a href="#" (click)="goToAddress($event, item.address)">{{item.address}}</a></td>
-                <td class="ellipsis width-15">{{(item.balance / 100000000)*currencyValue | number: '1.2-2'}} {{currencyName}}</td>
+                <td class="ellipsis width-15">{{(item.balance / 100000000)*currencyValue | currencyFormat}} {{currencyName}}</td>
                 <td class="ellipsis width-15">
                     <span *ngIf="supply">{{(item.balance / supply)*100 | number: '1.2-2'}}%</span>
                     <span *ngIf="!supply">0.00%</span>

--- a/src/app/pages/transaction/transaction.component.html
+++ b/src/app/pages/transaction/transaction.component.html
@@ -29,11 +29,11 @@
                 </div>
                 <div class="ark-summary-item ark-flex-between ark-flex-center" *ngIf="transaction.amount">
                     <span class="ark-summary-title">{{ 'GENERAL.INFO.AMOUNT' | translate }}</span>
-                    <div class="ark-summary-data">{{(transaction.amount / 100000000)*currencyValue | number: '1.2-2'}} <span class="opacity">{{currencyName}}</span></div>
+                    <div class="ark-summary-data">{{(transaction.amount / 100000000)*currencyValue | currencyFormat}} <span class="opacity">{{currencyName}}</span></div>
                 </div>
                 <div class="ark-summary-item ark-flex-between ark-flex-center" *ngIf="transaction.fee">
                     <span class="ark-summary-title">{{ 'GENERAL.INFO.FEE' | translate }}</span>
-                    <div class="ark-summary-data">{{(transaction.fee / 100000000)*currencyValue | number: '1.1-2'}} <span class="opacity">{{currencyName}}</span></div>
+                    <div class="ark-summary-data">{{(transaction.fee / 100000000)*currencyValue | currencyFormat}} <span class="opacity">{{currencyName}}</span></div>
                 </div>
                 <div class="ark-summary-item ark-flex-between ark-flex-center" *ngIf="transaction.timestamp">
                     <span class="ark-summary-title">{{ 'GENERAL.INFO.TIMESTAMP' | translate }}</span>
@@ -84,8 +84,8 @@
                                 <span *ngIf="transaction.asset && transaction.asset.signature">{{ 'TRANSACTION.ASSET.SIGNATURE' | translate }}</span>
                                 <span *ngIf="transaction.asset && transaction.asset.delegate">{{ 'TRANSACTION.ASSET.DELEGATE' | translate }}</span>
                             </td>
-                            <td class="ark-amount ellipsis width-15">{{(transaction.amount / 100000000)*currencyValue | number: '1.2-2'}} {{currencyName}}</td>
-                            <td class="ellipsis width-10">{{(transaction.fee / 100000000)*currencyValue | number: '1.1-2'}} {{currencyName}}</td>
+                            <td class="ark-amount ellipsis width-15">{{(transaction.amount / 100000000)*currencyValue | currencyFormat}} {{currencyName}}</td>
+                            <td class="ellipsis width-10">{{(transaction.fee / 100000000)*currencyValue | currencyFormat}} {{currencyName}}</td>
                             <td class="ellipsis width-15 ark-tooltip-wrap">
                                 <span *ngIf="transaction.confirmations <= 50">{{transaction.confirmations}}</span>
                                 <span *ngIf="transaction.confirmations > 50">{{ 'GENERAL.WELL_CONFIRMED' | translate }}</span>

--- a/src/app/shared/pipes/general.pipe.ts
+++ b/src/app/shared/pipes/general.pipe.ts
@@ -44,23 +44,14 @@ export class CurrencyFormatPipe implements PipeTransform {
 
     transform(value: number, overrideCurrency?: string): string {
         var formatted = '';
+        var formatCurrency = overrideCurrency ? overrideCurrency : this.currency;
 
-        if (overrideCurrency) {
-            if (overrideCurrency === 'ARK' || overrideCurrency === 'BTC') {
-                // 8 Decimal Places for Cryptocurrencies. Get rid of trailing 0's
-                formatted = value.toFixed(8).replace(/(?:\.0+|(\.\d+?)0+)$/, '$1');
-            } else {
-                // 2 Decimal Places for Fiat
-                formatted = value.toFixed(2);
-            }
+        if (formatCurrency === 'ARK' || formatCurrency === 'BTC') {
+            // 8 Decimal Places for Cryptocurrencies. Get rid of trailing 0's
+            formatted = value.toFixed(8).replace(/(?:\.0+|(\.\d+?)0+)$/, '$1');
         } else {
-            if (this.currency === 'ARK' || this.currency === 'BTC') {
-                // 8 Decimal Places for Cryptocurrencies. Get rid of trailing 0's
-                formatted = value.toFixed(8).replace(/(?:\.0+|(\.\d+?)0+)$/, '$1');
-            } else {
-                // 2 Decimal Places for Fiat
-                formatted = value.toFixed(2);
-            }
+            // 2 Decimal Places for Fiat
+            formatted = value.toFixed(2);
         }
 
         // Add commas

--- a/src/app/shared/pipes/general.pipe.ts
+++ b/src/app/shared/pipes/general.pipe.ts
@@ -54,6 +54,6 @@ export class CurrencyFormatPipe implements PipeTransform {
         }
 
         // Add commas
-        return formatted.replace(/\B(?=(?=\d*\.)(\d{3})+(?!\d))/g, ',');
+        return formatted.replace(/\B(?=(?=\d*\.||$)(\d{3})+(?!\d))/g, ',');
     }
 }

--- a/src/app/shared/pipes/general.pipe.ts
+++ b/src/app/shared/pipes/general.pipe.ts
@@ -1,4 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
+import { CurrencyService } from '../services/currency.service';
+import { initCurrency } from '../const/currency';
+import { Subscription } from 'rxjs/Subscription';
 
 @Pipe({ name: 'localDate' })
 export class DatePipe implements PipeTransform {
@@ -21,5 +24,36 @@ export class OverflowTextPipe implements PipeTransform {
         let last = value.substring(value.length - 5);
         
         return first + '...' + last;
+    }
+}
+
+@Pipe({ name: 'currencyFormat' })
+export class CurrencyFormatPipe implements PipeTransform {
+    private subscription: Subscription;
+    public currency: string = initCurrency.name;
+    public currencyRate: number = initCurrency.value;
+
+    constructor (
+        private _currencyService: CurrencyService
+    ) {
+        this.subscription = _currencyService.currencyChosen$.subscribe(currency => {
+          this.currency = currency.name;
+          this.currencyRate = currency.value;
+        });
+    }
+
+    transform(value: number): string {
+        var formatted = '';
+
+        if (this.currency === 'ARK' || this.currency === 'BTC') {
+            // 8 Decimal Places for Cryptocurrencies. Get rid of trailing 0's
+            formatted = value.toFixed(8).replace(/(?:\.0+|(\.\d+?)0+)$/, '$1');
+        } else {
+            // 2 Decimal Places for Fiat
+            formatted = value.toFixed(2);
+        }
+
+        // Add commas
+        return formatted.replace(/\B(?=(?=\d*\.)(\d{3})+(?!\d))/g, ',');
     }
 }

--- a/src/app/shared/pipes/general.pipe.ts
+++ b/src/app/shared/pipes/general.pipe.ts
@@ -46,7 +46,7 @@ export class CurrencyFormatPipe implements PipeTransform {
         var formatted = '';
 
         if (overrideCurrency) {
-            if (overrideCurrency === 'ARK' || this.currency === 'BTC') {
+            if (overrideCurrency === 'ARK' || overrideCurrency === 'BTC') {
                 // 8 Decimal Places for Cryptocurrencies. Get rid of trailing 0's
                 formatted = value.toFixed(8).replace(/(?:\.0+|(\.\d+?)0+)$/, '$1');
             } else {

--- a/src/app/shared/pipes/general.pipe.ts
+++ b/src/app/shared/pipes/general.pipe.ts
@@ -42,15 +42,25 @@ export class CurrencyFormatPipe implements PipeTransform {
         });
     }
 
-    transform(value: number): string {
+    transform(value: number, overrideCurrency?: string): string {
         var formatted = '';
 
-        if (this.currency === 'ARK' || this.currency === 'BTC') {
-            // 8 Decimal Places for Cryptocurrencies. Get rid of trailing 0's
-            formatted = value.toFixed(8).replace(/(?:\.0+|(\.\d+?)0+)$/, '$1');
+        if (overrideCurrency) {
+            if (overrideCurrency === 'ARK' || this.currency === 'BTC') {
+                // 8 Decimal Places for Cryptocurrencies. Get rid of trailing 0's
+                formatted = value.toFixed(8).replace(/(?:\.0+|(\.\d+?)0+)$/, '$1');
+            } else {
+                // 2 Decimal Places for Fiat
+                formatted = value.toFixed(2);
+            }
         } else {
-            // 2 Decimal Places for Fiat
-            formatted = value.toFixed(2);
+            if (this.currency === 'ARK' || this.currency === 'BTC') {
+                // 8 Decimal Places for Cryptocurrencies. Get rid of trailing 0's
+                formatted = value.toFixed(8).replace(/(?:\.0+|(\.\d+?)0+)$/, '$1');
+            } else {
+                // 2 Decimal Places for Fiat
+                formatted = value.toFixed(2);
+            }
         }
 
         // Add commas

--- a/src/app/shared/pipes/general.pipe.ts
+++ b/src/app/shared/pipes/general.pipe.ts
@@ -64,6 +64,10 @@ export class CurrencyFormatPipe implements PipeTransform {
         }
 
         // Add commas
-        return formatted.replace(/\B(?=(?=\d*\.|$)(\d{3})+(?!\d))/g, ',');
+        if (formatted.includes('.')) {
+            return formatted.replace(/\B(?=(?=\d*\.)(\d{3})+(?!\d))/g, ',');
+        } else {
+            return formatted.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+        }
     }
 }

--- a/src/app/shared/pipes/general.pipe.ts
+++ b/src/app/shared/pipes/general.pipe.ts
@@ -64,6 +64,6 @@ export class CurrencyFormatPipe implements PipeTransform {
         }
 
         // Add commas
-        return formatted.replace(/\B(?=(?=\d*\.||$)(\d{3})+(?!\d))/g, ',');
+        return formatted.replace(/\B(?=(?=\d*\.|$)(\d{3})+(?!\d))/g, ',');
     }
 }

--- a/src/app/shared/services/currency.service.ts
+++ b/src/app/shared/services/currency.service.ts
@@ -28,7 +28,6 @@ export class CurrencyService {
       name: currency,
       value: value
     };
-    console.log(i.name);
     this.currencySource.next(i);
   }
 

--- a/src/app/shared/services/currency.service.ts
+++ b/src/app/shared/services/currency.service.ts
@@ -13,7 +13,7 @@ import 'rxjs/Rx';
 export class CurrencyService {
   private currencySource = new Subject<CurrencyModel>();
   private supplySource = new Subject<number>();
-  private heightSourse = new Subject<number>();
+  private heightSource = new Subject<number>();
 
   constructor(
     private http: Http
@@ -21,13 +21,14 @@ export class CurrencyService {
 
   currencyChosen$ = this.currencySource.asObservable();
   supplyChosen$ = this.supplySource.asObservable();
-  heightChosen$ = this.heightSourse.asObservable();
+  heightChosen$ = this.heightSource.asObservable();
 
   changeCurrency(currency: string, value: number) {
     let i: CurrencyModel = {
       name: currency,
       value: value
     };
+    console.log(i.name);
     this.currencySource.next(i);
   }
 
@@ -36,7 +37,7 @@ export class CurrencyService {
   }
 
   changeHeight(value: number) {
-    this.heightSourse.next(value);
+    this.heightSource.next(value);
   }
 
   public getCNYprice() {


### PR DESCRIPTION
Created a pipe to format currencies based on whether the selected currency is crypto (8 decimal places) or fiat (2 decimal places). It also strips 0's from the end of a number (ex. 123.50000000 -> 123.5). By default it uses the selected currency, but it can be overridden with an optional argument (for values that are always in one specific currency like in the header).

Resolves #9 