### PR TITLE
Fix bug "Cannot read property 'price' of undefined" (CNY exception)

### DIFF
--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -54,10 +54,6 @@
                     <span class="ark-index-title"> ARK/GBP:</span>
                     <span class="ark-index-data">{{headerGBP  | number: '1.0-2'}}</span>
                 </span>
-                <span class="ark-item-index" *ngIf="headerCNY">
-                    <span class="ark-index-title"> ARK/CNY:</span>
-                    <span class="ark-index-data">{{headerCNY  | number: '1.0-2'}}</span>
-                </span>
             </div>
         </div>
     </div>

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -21,7 +21,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
   public headerBTC: any;
   public headerUSD: any;
   public headerEUR: any;
-  public headerCNY: any;
   public headerGBP: any;
 
   public openMobileMenu: boolean = false;
@@ -64,7 +63,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.getCNYprice();
     this.getGBPprice();
     this.getExtraRates();
   }
@@ -79,7 +77,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
 
   getExtraRates() {
     this._timer = setInterval(() => {
-      this.getCNYprice();
       this.getGBPprice();
     }, 5*60000);
   }
@@ -104,16 +101,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
     if (this._timer) {
       clearInterval(this._timer);
     }
-  }
-  
-  private getCNYprice(): void {
-    this._currencyService.getCNYprice().subscribe(res => {
-      if (!res.ticker) {
-        return;
-      }
-
-      this.headerCNY = res.ticker.price;
-    });
   }
 
   private getGBPprice(): void {

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -64,12 +64,8 @@ export class HeaderComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this._currencyService.getCNYprice().subscribe(res => {
-      this.headerCNY = res.ticker.price;
-    });
-    this._currencyService.getGBPprice().subscribe(res => {
-      this.headerGBP = res.ticker.price;
-    });
+    this.getCNYprice();
+    this.getGBPprice();
     this.getExtraRates();
   }
 
@@ -83,12 +79,8 @@ export class HeaderComponent implements OnInit, OnDestroy {
 
   getExtraRates() {
     this._timer = setInterval(() => {
-      this._currencyService.getCNYprice().subscribe(res => {
-        this.headerCNY = res.ticker.price;
-      });
-      this._currencyService.getGBPprice().subscribe(res => {
-        this.headerGBP = res.ticker.price;
-      });
+      this.getCNYprice();
+      this.getGBPprice();
     }, 5*60000);
   }
 
@@ -112,5 +104,25 @@ export class HeaderComponent implements OnInit, OnDestroy {
     if (this._timer) {
       clearInterval(this._timer);
     }
+  }
+  
+  private getCNYprice(): void {
+    this._currencyService.getCNYprice().subscribe(res => {
+      if (!res.ticker) {
+        return;
+      }
+
+      this.headerCNY = res.ticker.price;
+    });
+  }
+
+  private getGBPprice(): void {
+    this._currencyService.getGBPprice().subscribe(res => {
+      if (!res.ticker) {
+        return;
+      }
+
+      this.headerGBP = res.ticker.price;
+    });
   }
 }

--- a/src/app/shared/services/currency.service.ts
+++ b/src/app/shared/services/currency.service.ts
@@ -44,12 +44,6 @@ export class CurrencyService {
     this.heightSourse.next(value);
   }
 
-  public getCNYprice() {
-    return this.http.get(`https://api.cryptonator.com/api/ticker/ark-cny`)
-      .map((res: Response) => res.json())
-      .catch((error: any) => Observable.throw(error.json()));
-  }
-
   public getGBPprice() {
     return this.http.get(`https://api.cryptonator.com/api/ticker/ark-gbp`)
       .map((res: Response) => res.json())


### PR DESCRIPTION
I saw this exception while developing another feature (also visible on the productive ark explorer, if you open the developer console):

```
core.es5.js:1020 ERROR TypeError: Cannot read property 'price' of undefined
    at SafeSubscriber._next (header.component.ts:69)
    at SafeSubscriber.webpackJsonp.../../../../rxjs/Subscriber.js.SafeSubscriber.__tryOrUnsub (Subscriber.js:238)
    at SafeSubscriber.webpackJsonp.../../../../rxjs/Subscriber.js.SafeSubscriber.next (Subscriber.js:185)
    at Subscriber.webpackJsonp.../../../../rxjs/Subscriber.js.Subscriber._next (Subscriber.js:125)
    at Subscriber.webpackJsonp.../../../../rxjs/Subscriber.js.Subscriber.next (Subscriber.js:89)
    at CatchSubscriber.webpackJsonp.../../../../rxjs/Subscriber.js.Subscriber._next (Subscriber.js:125)
    at CatchSubscriber.webpackJsonp.../../../../rxjs/Subscriber.js.Subscriber.next (Subscriber.js:89)
    at MapSubscriber.webpackJsonp.../../../../rxjs/operator/map.js.MapSubscriber._next (map.js:83)
    at MapSubscriber.webpackJsonp.../../../../rxjs/Subscriber.js.Subscriber.next (Subscriber.js:89)
    at XMLHttpRequest.onLoad (http.es5.js:1226)
```
The fix was easy (see commit 5e238a7).
However I realized that `cryptonator.com` doesn't support `CNY` anymore (see https://www.cryptonator.com/api/currencies). So I removed `CNY` completely from the code (21701d1). Obviously another solution would be to find and use another API for it.

What do you prefer / want?