### PR TITLE
Fix or delete karma tests

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,13 +1,50 @@
 import { TestBed, async } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { FormsModule } from '@angular/forms';
 
 import { AppComponent } from './app.component';
+import { HeaderComponent } from './components/header/header.component';
+import { FooterComponent } from './components/footer/footer.component';
+import { ScrollTopComponent } from './components/scroll-top/scroll-top.component';
+import { TranslatePipe, TranslateModule } from '@ngx-translate/core';
+import { ToggleBackgroundComponent } from './components/header/toggle-background/toggle-background.component';
+import { CurrencyDropdownComponent } from './components/header/currency-dropdown/currency-dropdown.component';
+import { ToolsDropdownComponent } from './components/header/tools-dropdown/tools-dropdown.component';
+import { SocketHeaderService, SocketGraphService, SocketMonitorService } from './shared/services/socket.service';
+import { CurrencyService } from './shared/services/currency.service';
+import { HttpModule } from '@angular/http';
+import { ThemeService } from './shared/services/theme.service';
+import { ConnectionMessageService } from './shared/services/connection-message.service';
 
 describe('AppComponent', () => {
   beforeEach(async(() => {
+   // originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+  //  jasmine.DEFAULT_TIMEOUT_INTERVAL = 2500000;
     TestBed.configureTestingModule({
       declarations: [
-        AppComponent
+        AppComponent,
+        HeaderComponent,
+        FooterComponent,
+        ScrollTopComponent,
+        ToggleBackgroundComponent,
+        CurrencyDropdownComponent,
+        ToolsDropdownComponent
       ],
+      imports: [ 
+        RouterTestingModule,
+        FormsModule,
+        HttpModule,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        SocketHeaderService,
+        SocketGraphService,
+        SocketMonitorService,
+        CurrencyService,
+        ThemeService,
+        ConnectionMessageService
+      ]
     }).compileComponents();
   }));
 
@@ -17,16 +54,16 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   }));
 
-  it(`should have as title 'app'`, async(() => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.debugElement.componentInstance;
-    expect(app.title).toEqual('app');
-  }));
+  // it(`should have as title 'app'`, async(() => {
+  //   const fixture = TestBed.createComponent(AppComponent);
+  //   const app = fixture.debugElement.componentInstance;
+  //   expect(app.title).toEqual('app');
+  // }));
 
-  it('should render title in a h1 tag', async(() => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector('h1').textContent).toContain('Welcome to app!');
-  }));
+  // it('should render title in a h1 tag', async(() => {
+  //   const fixture = TestBed.createComponent(AppComponent);
+  //   fixture.detectChanges();
+  //   const compiled = fixture.debugElement.nativeElement;
+  //   expect(compiled.querySelector('h1').textContent).toContain('Welcome to app!');
+  // }));
 });


### PR DESCRIPTION
While implementing #37 I created some tests and wanted to execute (`npm run test`).
However it appears that almost no tests are working / passing, most of them are failing with something like this:

![image](https://user-images.githubusercontent.com/1086065/33724333-75853e4c-db6f-11e7-9be4-5c9aad404f31.png)

I decided to try fixing them and started with the - obvious choice - `AppComponent`. Basically I needed to declare and import a lof of stuff and then I got a step further:

```
AppComponent should create the app
Error: Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL.
```
I invested some time to find out what's the problem could be here, but I didn't find it just yet.

So you may be wondering - why bother open a PR then?

Well after I failed I looked what our unit (karma) tests even do.
And honestly they are just the out of the box tests from angular cli.
I personally find these kind of tests not useful & meaning full at all.

Examples for `AppComponent`:
 - should create the app
 - should have as title 'app'
 - should render title in a h1 tag

The first test may still be "fitting" to the explorer, the other two however are not even correct anymore.

As mentioned above I find this "created app" and "h1 should contain that" tests not really useful - even if they would be correct and work again.
For me testing real "logical functionality" is way more important than testing if a component could be created or not.

So my proposal is simple (maybe a little bold ,but that's why I'm asking first):
Just delete all these tests and leave only REALLY meaningful tests there (if there are even any, I did some in my other PR (at least in my eyes ;) ).

Well let me know what you think!