### PR TITLE
Replace all onclick links with real links

### DIFF
--- a/src/app/pages/address/address-transactions/address-transactions.component.html
+++ b/src/app/pages/address/address-transactions/address-transactions.component.html
@@ -13,17 +13,17 @@
     <tbody>
         <tr *ngFor="let item of items">
             <td class="ark-transaction ellipsis width-15 ark-tooltip-wrap" [ngClass]="{'ark-transaction': item.vendorField}">
-                <a href="#" (click)="goToTransaction($event, item.id)">{{item.id | overflowText}}</a>
+                <a [routerLink]="['/tx', item.id]">{{item.id | overflowText}}</a>
                 <span class="ark-tooltip" *ngIf="item.vendorField">{{ item.vendorField }}</span>
             </td>
             <td class="ellipsis width-15">{{item.timestamp | localDate | amDateFormat:'YYYY-MM-DD HH:mm:ss'}}</td>
             <td class="ark-blue-text ellipsis width-15">
-                <a href="#" *ngIf="item.senderDelegate" (click)="goToAddress($event, item.senderId)">{{item.senderDelegate.username}}</a>
-                <a href="#" *ngIf="!item.senderDelegate && item.knownSender" (click)="goToAddress($event, item.senderId)">{{item.knownSender.owner}}</a>
-                <a href="#" *ngIf="!item.senderDelegate && !item.knownSender" (click)="goToAddress($event, item.senderId)">{{item.senderId | overflowText}}</a>
+                <a [routerLink]="getAddressLink(item.senderId)" *ngIf="item.senderDelegate">{{item.senderDelegate.username}}</a>
+                <a [routerLink]="getAddressLink(item.senderId)" *ngIf="!item.senderDelegate && item.knownSender">{{item.knownSender.owner}}</a>
+                <a [routerLink]="getAddressLink(item.senderId)" *ngIf="!item.senderDelegate && !item.knownSender">{{item.senderId | overflowText}}</a>
             </td>
             <td class="ellipsis width-15">
-                <a href="#" (click)="goToAddress($event, item.recipientId)" *ngIf="!(item.asset && item.asset.votes || item.asset && item.asset.signature || item.asset && item.asset.delegate)">{{item.recipientId | overflowText}}</a>
+                <a [routerLink]="getAddressLink(item.recipientId)" *ngIf="!(item.asset && item.asset.votes || item.asset && item.asset.signature || item.asset && item.asset.delegate)">{{item.recipientId | overflowText}}</a>
                 <span *ngIf="item.asset && item.asset.votes">{{ 'TRANSACTION.ASSET.VOTES' | translate }}</span>
                 <span *ngIf="item.asset && item.asset.signature">{{ 'TRANSACTION.ASSET.SIGNATURE' | translate }}</span>
                 <span *ngIf="item.asset && item.asset.delegate">{{ 'TRANSACTION.ASSET.DELEGATE' | translate }}</span>

--- a/src/app/pages/address/address-transactions/address-transactions.component.ts
+++ b/src/app/pages/address/address-transactions/address-transactions.component.ts
@@ -17,19 +17,7 @@ export class AddressTransactionsComponent implements OnInit {
   ngOnInit() {
   }
 
-  goToAddress(event, id: string) {
-    event.preventDefault();
-    this.router.navigate(['/address', id]);
+  getAddressLink(id: string) {
+    return ['/address', id];
   }
-
-  goToBlock(event, id: string) {
-    event.preventDefault();
-    this.router.navigate(['/block', id]);
-  }
-
-  goToTransaction(event, id: string) {
-    event.preventDefault();
-    this.router.navigate(['/tx', id]);
-  }
-
 }

--- a/src/app/pages/address/address.component.html
+++ b/src/app/pages/address/address.component.html
@@ -84,12 +84,12 @@
             <div class="ark-address-summary voters-container" style="display: block;" *ngIf="!openVoters" #voters>
                 <div class="voters-button" (click)="showBlock()"></div>
                 <span class="voters-address" *ngFor="let item of addressItem.voters; let i = index;">
-                    <a href="#" (click)="goToAddress($event, item.address)" *ngIf="i < votersNumber">{{item.address}} ({{(item.balance / 100000000) | number: '1.2-2'}} ARK)</a>
+                    <a [routerLink]="getAddressLink(item.address)" *ngIf="i < votersNumber">{{item.address}} ({{(item.balance / 100000000) | number: '1.2-2'}} ARK)</a>
                 </span>
             </div>
             <div class="ark-address-summary voters-container open" style="display: block;" *ngIf="openVoters" #voters>
                 <div class="voters-button" (click)="showBlock()"></div>
-                <span class="voters-address" *ngFor="let item of addressItem.voters"><a href="#" (click)="goToAddress($event, item.address)">{{item.address}} ({{(item.balance / 100000000) | number: '1.2-2'}} ARK)</a> </span>
+                <span class="voters-address" *ngFor="let item of addressItem.voters"><a [routerLink]="getAddressLink(item.address)">{{item.address}} ({{(item.balance / 100000000) | number: '1.2-2'}} ARK)</a> </span>
             </div>
         </div>
         <!-- voters blocks -->

--- a/src/app/pages/address/address.component.ts
+++ b/src/app/pages/address/address.component.ts
@@ -145,9 +145,8 @@ export class AddressComponent implements OnInit, OnDestroy {
     this.openVoters = !this.openVoters;
   }
 
-  goToAddress(event, id: string) {
-    event.preventDefault();
-    this.router.navigate(['/address', id]);
+  getAddressLink(id: string) {
+    return ['/address', id];
   }
 
   ngOnDestroy() {

--- a/src/app/pages/block-list/block-list.component.html
+++ b/src/app/pages/block-list/block-list.component.html
@@ -14,11 +14,11 @@
         </thead>
         <tbody>
             <tr *ngFor="let item of blocks">
-                <td class="ellipsis width-15"><a href="#" (click)="goToBlock($event, item.id)">{{item.id}}</a></td>
+                <td class="ellipsis width-15"><a [routerLink]="['/block', item.id]">{{item.id}}</a></td>
                 <td class="ellipsis width-10">{{item.height}}</td>
                 <td class="ellipsis width-15">{{item.timestamp | localDate | amDateFormat:'YYYY-MM-DD HH:mm:ss'}}</td>
                 <td class="ellipsis width-15">{{item.transactionsCount}}</td>
-                <td class="ellipsis width-15"><a href="#" (click)="goToAddress($event, item.delegate.address)">{{item.delegate.username}}</a></td>
+                <td class="ellipsis width-15"><a [routerLink]="['/address', item.delegate.address]">{{item.delegate.username}}</a></td>
                 <td class="ellipsis width-15">{{(item.totalAmount/100000000)*currencyValue | number: '1.2-2'}}</td>
                 <td class="ellipsis width-15">{{(item.totalForged/100000000)*currencyValue | number: '1.0-2'}}</td>
             </tr>
@@ -29,7 +29,17 @@
         <p>{{ 'GENERAL.LOADING' | translate }}...</p>
     </div>
     <div class="ark-pagination ark-flex ark-flex-between">
-        <div class="ark-pagination-prev" *ngIf="pagination && pagination.previousPage" (click)="goToPage(pagination.previousPage)"><i class="fa fa-angle-left angle-icon" aria-hidden="true"></i> {{ 'GENERAL.PREV_PAGE' | translate }}</div>
-        <div class="ark-pagination-next" *ngIf="pagination && pagination.nextPage" (click)="goToPage(pagination.nextPage)">{{ 'GENERAL.NEXT_PAGE' | translate }} <i class="fa fa-angle-right angle-icon" aria-hidden="true"></i></div>
+        <div class="ark-pagination-prev" *ngIf="pagination && pagination.previousPage">
+            <i class="fa fa-angle-left angle-icon" aria-hidden="true"></i>
+            <a [routerLink]="getPageLink(pagination.previousPage)" (click)="changePage()">
+                {{ 'GENERAL.PREV_PAGE' | translate }}
+            </a>
+        </div>
+        <div class="ark-pagination-next" *ngIf="pagination && pagination.nextPage">
+            <a [routerLink]="getPageLink(pagination.nextPage)" (click)="changePage()">
+                {{ 'GENERAL.NEXT_PAGE' | translate }}
+            </a>
+            <i class="fa fa-angle-right angle-icon" aria-hidden="true"></i>
+        </div>
     </div>
 </section>

--- a/src/app/pages/block-list/block-list.component.ts
+++ b/src/app/pages/block-list/block-list.component.ts
@@ -55,20 +55,13 @@ export class BlockListComponent implements OnInit, OnDestroy {
     });
   }
 
-  goToAddress(event, id: string) {
-    event.preventDefault();
-    this.router.navigate(['/address', id]);
-  }
-
-  goToBlock(event, id: string) {
-    event.preventDefault();
-    this.router.navigate(['/block', id]);
-  }
-
-  goToPage(page: number) {
+  changePage() {
     this.blocks = [];
     this.showLoader = true;
-    this.router.navigate(['/blocks', page]);
+  }
+
+  getPageLink(page: number) {
+    return ['/blocks', page];
   }
 
   ngOnDestroy() {

--- a/src/app/pages/block/block.component.html
+++ b/src/app/pages/block/block.component.html
@@ -47,11 +47,11 @@
                 </div>
                 <div class="ark-summary-item ark-flex-between ark-flex-center">
                     <span class="ark-summary-title">{{ 'BLOCK.PREV_BLOCK' | translate }}</span>
-                    <div class="ark-summary-data"><a href="#" (click)="goToBlock($event, block.previousBlock)">{{block.previousBlock}}</a></div>
+                    <div class="ark-summary-data"><a [routerLink]="['/block', block.previousBlock]">{{block.previousBlock}}</a></div>
                 </div>
                 <div class="ark-summary-item ark-flex-between ark-flex-center">
                     <span class="ark-summary-title">{{ 'GENERAL.INFO.GENERATED_BY' | translate }}</span>
-                    <div class="ark-summary-data"><a href="#" (click)="goToAddress($event, block.generatorId)">{{block.delegate.username}}</a></div>
+                    <div class="ark-summary-data"><a [routerLink]="getAddressLink(block.generatorId)">{{block.delegate.username}}</a></div>
                 </div>
             </div>
         </div>
@@ -73,17 +73,17 @@
                     <tbody *ngIf="transactions && transactions.length">
                         <tr *ngFor="let transaction of transactions">
                             <td class="ark-transaction ellipsis width-15 ark-tooltip-wrap" [ngClass]="{'ark-transaction': transaction.vendorField}">
-                                <a href="#" (click)="goToTransaction($event, transaction.id)">{{transaction.id | overflowText}}</a>
+                                <a [routerLink]="['/tx', transaction.id]">{{transaction.id | overflowText}}</a>
                                 <span class="ark-tooltip" *ngIf="transaction.vendorField">{{ transaction.vendorField }}</span>
                             </td>
                             <td class="ellipsis width-15">{{transaction.timestamp | localDate | amDateFormat:'YYYY-MM-DD HH:mm:ss'}}</td>
                             <td class="ark-blue-text ellipsis width-15">
-                                <a href="#" *ngIf="transaction.senderDelegate" (click)="goToAddress($event, transaction.senderId)">{{transaction.senderDelegate.username}}</a>
-                                <a href="#" *ngIf="!transaction.senderDelegate && transaction.knownSender" (click)="goToAddress($event, transaction.senderId)">{{transaction.knownSender.owner}}</a>
-                                <a href="#" *ngIf="!transaction.senderDelegate && !transaction.knownSender" (click)="goToAddress($event, transaction.senderId)">{{transaction.senderId | overflowText}}</a>
+                                <a *ngIf="transaction.senderDelegate" [routerLink]="getAddressLink(transaction.senderId)">{{transaction.senderDelegate.username}}</a>
+                                <a *ngIf="!transaction.senderDelegate && transaction.knownSender" [routerLink]="getAddressLink(transaction.senderId)">{{transaction.knownSender.owner}}</a>
+                                <a *ngIf="!transaction.senderDelegate && !transaction.knownSender" [routerLink]="getAddressLink(transaction.senderId)">{{transaction.senderId | overflowText}}</a>
                             </td>
                             <td class="ellipsis width-15">
-                                <a href="#" (click)="goToAddress($event, transaction.recipientId)" *ngIf="!((transaction.asset && transaction.asset.votes) || transaction.asset && transaction.asset.signature || transaction.asset && transaction.asset.delegate)">{{transaction.recipientId | overflowText}}</a>
+                                <a [routerLink]="getAddressLink(transaction.recipientId)" *ngIf="!((transaction.asset && transaction.asset.votes) || transaction.asset && transaction.asset.signature || transaction.asset && transaction.asset.delegate)">{{transaction.recipientId | overflowText}}</a>
                                 <span *ngIf="transaction.asset && transaction.asset.votes">{{ 'TRANSACTION.ASSET.VOTES' | translate }}</span>
                                 <span *ngIf="transaction.asset && transaction.asset.signature">{{ 'TRANSACTION.ASSET.SIGNATURE' | translate }}</span>
                                 <span *ngIf="transaction.asset && transaction.asset.delegate">{{ 'TRANSACTION.ASSET.DELEGATE' | translate }}</span>

--- a/src/app/pages/block/block.component.ts
+++ b/src/app/pages/block/block.component.ts
@@ -55,19 +55,8 @@ export class BlockComponent implements OnInit, OnDestroy {
     });
   }
 
-  goToAddress(event, id: string) {
-    event.preventDefault();
-    this.router.navigate(['/address', id]);
-  }
-
-  goToBlock(event, id: string) {
-    event.preventDefault();
-    this.router.navigate(['/block', id]);
-  }
-
-  goToTransaction(event, id: string) {
-    event.preventDefault();
-    this.router.navigate(['/tx', id]);
+  getAddressLink(id: string) {
+    return ['/address', id];
   }
 
   ngOnDestroy() {

--- a/src/app/pages/delegate-monitor/delegate-monitor.component.html
+++ b/src/app/pages/delegate-monitor/delegate-monitor.component.html
@@ -21,11 +21,11 @@
             <li>
                 <div class="ark-title">{{ 'DELEGATE_MONITOR.MONITOR.LAST_BLOCK' | translate}}</div>
                 <div class="ark-count">
-                    <span *ngIf="monitorData && monitorData.lastBlock"><a href="#" (click)="goToAddress($event, monitorData.lastBlock.block.delegate.address)">{{monitorData.lastBlock.block.delegate.username}}</a></span>
+                    <span *ngIf="monitorData && monitorData.lastBlock"><a [routerLink]="getAddressLink(monitorData.lastBlock.block.delegate.address)">{{monitorData.lastBlock.block.delegate.username}}</a></span>
                     <span *ngIf="!monitorData">N/A</span>
                 </div>
                 <div class="ark-info-item">
-                    <span *ngIf="monitorData && monitorData.lastBlock"><a href="#" (click)="goToBlock($event, monitorData.lastBlock.block.id)">{{monitorData.lastBlock.block.id}}</a></span>
+                    <span *ngIf="monitorData && monitorData.lastBlock"><a [routerLink]="['/block', monitorData.lastBlock.block.id]">{{monitorData.lastBlock.block.id}}</a></span>
                     <span *ngIf="!monitorData">N/A</span>
                 </div>
                 <div class="ark-info-item">
@@ -39,12 +39,12 @@
             <li>
                 <div class="ark-title">{{ 'DELEGATE_MONITOR.MONITOR.NEXT_FORGERS' | translate}}</div>
                 <div class="ark-count" *ngIf="monitorData && monitorData.nextForgers">
-                    <a href="#" (click)="goToAddress($event, monitorData.nextForgers[0].address)">{{monitorData.nextForgers[0].username}}</a>
+                    <a [routerLink]="getAddressLink(monitorData.nextForgers[0].address)">{{monitorData.nextForgers[0].username}}</a>
                 </div>
                 <div class="ark-message" *ngIf="!monitorData">{{ 'DELEGATE_MONITOR.MONITOR.WAITING' | translate}}</div>
                 <div class="ark-info-item" *ngIf="monitorData && monitorData.nextForgers">
                     <span *ngFor="let item of monitorData.nextForgers; let i = index;">
-                        <a href="#" (click)="goToAddress($event, item.address)">{{item.username}}</a>
+                        <a [routerLink]="getAddressLink(item.address)">{{item.username}}</a>
                         <span *ngIf="i !== monitorData.nextForgers.length - 1"> - </span>
                     </span>
                 </div>
@@ -59,7 +59,7 @@
             <li>
                 <div class="ark-title">{{ 'DELEGATE_MONITOR.MONITOR.BEST_FORGER' | translate }}</div>
                 <div class="ark-count">
-                    <span *ngIf="bestForger"><a href="#" (click)="goToAddress($event, bestForger.address)">{{bestForger.username}}</a></span>
+                    <span *ngIf="bestForger"><a [routerLink]="getAddressLink(bestForger.address)">{{bestForger.username}}</a></span>
                     <span *ngIf="!bestForger">N/A</span>
                 </div>
                 <div class="ark-info-item phrase-wrap">
@@ -75,7 +75,7 @@
                     <span *ngIf="!productivity">0%</span>
                 </div>
                 <div class="ark-info-item">{{ 'GENERAL.BY' | translate}}
-                    <a href="#" *ngIf="productivity" (click)="goToAddress($event, productivity.best.address)">{{productivity.best.username}}</a>
+                    <a *ngIf="productivity" [routerLink]="getAddressLink(productivity.best.address)">{{productivity.best.username}}</a>
                     <span *ngIf="!productivity">N/A</span>
                 </div>
                 <div class="ark-gradient-border blue-gradient"></div>
@@ -87,7 +87,7 @@
                     <span *ngIf="!productivity">0%</span>
                 </div>
                 <div class="ark-info-item">{{ 'GENERAL.BY' | translate}}
-                    <a href="#" *ngIf="productivity" (click)="goToAddress($event, productivity.worst.address)">{{productivity.worst.username}}</a>
+                    <a *ngIf="productivity" [routerLink]="getAddressLink(productivity.worst.address)">{{productivity.worst.username}}</a>
                     <span *ngIf="!productivity">N/A</span>
                 </div>
                 <div class="ark-gradient-border pink-gradient"></div>
@@ -121,8 +121,8 @@
                     </thead>
                     <tbody *ngIf="monitorData && monitorData.votes">
                         <tr *ngFor="let item of monitorData.votes.transactions">
-                            <td class="ellipsis width-15"><a href="#" (click)="goToAddress($event, item.senderId)">{{item.senderId | overflowText}}</a></td>
-                            <td class="ellipsis width-15"><a href="#" (click)="goToTransaction($event, item.id)">{{item.id | overflowText}}</a></td>
+                            <td class="ellipsis width-15"><a [routerLink]="getAddressLink(item.senderId)">{{item.senderId | overflowText}}</a></td>
+                            <td class="ellipsis width-15"><a [routerLink]="getTransactionLink(item.id)">{{item.id | overflowText}}</a></td>
                             <td class="ellipsis width-15">{{item.timestamp | localDate | amTimeAgo}}</td>
                             <td></td>
                         </tr>
@@ -146,8 +146,8 @@
                     </thead>
                     <tbody *ngIf="monitorData && monitorData.registrations">
                         <tr *ngFor="let item of monitorData.registrations.transactions">
-                            <td class="ellipsis width-10"><a href="#" (click)="goToAddress($event, item.delegate.address)">{{item.delegate.username}}</a></td>
-                            <td class="ellipsis width-15"><a href="#" (click)="goToTransaction($event, item.id)">{{item.id | overflowText}}</a></td>
+                            <td class="ellipsis width-10"><a [routerLink]="getAddressLink(item.delegate.address)">{{item.delegate.username}}</a></td>
+                            <td class="ellipsis width-15"><a [routerLink]="getTransactionLink(item.id)">{{item.id | overflowText}}</a></td>
                             <td class="ellipsis width-15">{{item.timestamp | localDate | amTimeAgo}}</td>
                             <td></td>
                         </tr>

--- a/src/app/pages/delegate-monitor/delegate-monitor.component.ts
+++ b/src/app/pages/delegate-monitor/delegate-monitor.component.ts
@@ -113,19 +113,12 @@ export class DelegateMonitorComponent implements OnInit, OnDestroy {
     this._marketService.build(this.activeChartTab);
   }
 
-  goToAddress(event, id: string) {
-    event.preventDefault();
-    this.router.navigate(['/address', id]);
+  getAddressLink(id: string) {
+    return ['/address', id];
   }
 
-  goToTransaction(event, id: string) {
-    event.preventDefault();
-    this.router.navigate(['/tx', id]);
-  }
-
-  goToBlock(event, id: string) {
-    event.preventDefault();
-    this.router.navigate(['/block', id]);
+  getTransactionLink(id: string) {
+    return ['/tx', id];
   }
 
   ngOnDestroy() {

--- a/src/app/pages/delegate-monitor/delegates/delegates.component.html
+++ b/src/app/pages/delegate-monitor/delegates/delegates.component.html
@@ -14,7 +14,7 @@
     <tbody *ngIf="list">
         <tr *ngFor="let item of list">
             <td class="ellipsis width-15">{{item.rate}}</td>
-            <td class="ellipsis width-15"><a href="#" (click)="goToAddress($event, item.address)">{{item.username}}</a></td>
+            <td class="ellipsis width-15"><a [routerLink]="['/address', item.address]">{{item.username}}</a></td>
             <td class="ellipsis width-20">{{item.address}}</td>
             <td class="ellipsis width-15" *ngIf="active">{{(item.forged/100000000)*curValue | number: '1.2-2'}} <span class="opacity">{{curName}}</span></td>
             <td class="ellipsis width-15" *ngIf="active">{{item.forgingTime | amDuration:'seconds'}}</td>

--- a/src/app/pages/delegate-monitor/delegates/delegates.component.ts
+++ b/src/app/pages/delegate-monitor/delegates/delegates.component.ts
@@ -16,10 +16,4 @@ export class DelegatesComponent implements OnInit {
 
   ngOnInit() {
   }
-
-  goToAddress(event, id: string) {
-    event.preventDefault();
-    this.router.navigate(['/address', id]);
-  }
-
 }

--- a/src/app/pages/explorer/explorer.component.html
+++ b/src/app/pages/explorer/explorer.component.html
@@ -25,12 +25,12 @@
         </thead>
         <tbody>
             <tr *ngFor="let item of transactions">
-                <td class="ellipsis width-15 ark-tooltip-wrap" [ngClass]="{'ark-transaction': item.vendorField}"><a href="#" (click)="goToTransaction($event, item.id)">{{item.id | overflowText}}</a>
+                <td class="ellipsis width-15 ark-tooltip-wrap" [ngClass]="{'ark-transaction': item.vendorField}"><a [routerLink]="['/tx', item.id]">{{item.id | overflowText}}</a>
                     <span class="ark-tooltip" *ngIf="item.vendorField">{{ item.vendorField }}</span>
                 </td>
                 <td class="ellipsis width-15">{{item.timestamp | localDate | amDateFormat:'YYYY-MM-DD HH:mm:ss'}}</td>
-                <td class="ellipsis width-15"><a href="#" (click)="goToAddress($event, item.senderId)"><span *ngIf="item.senderDelegate">{{item.senderDelegate.username}}</span> <span *ngIf="!item.senderDelegate">{{item.senderId | overflowText}}</span></a></td>
-                <td class="ellipsis width-15"><a href="#" (click)="goToAddress($event, item.recipientId)">{{item.recipientId | overflowText}}</a></td>
+                <td class="ellipsis width-15"><a [routerLink]="getAddressLink(item.senderId)"><span *ngIf="item.senderDelegate">{{item.senderDelegate.username}}</span> <span *ngIf="!item.senderDelegate">{{item.senderId | overflowText}}</span></a></td>
+                <td class="ellipsis width-15"><a [routerLink]="getAddressLink(item.recipientId)">{{item.recipientId | overflowText}}</a></td>
                 <td class="ellipsis width-20">{{item.vendorField || ''}}</td>
                 <td class="ellipsis width-15">{{(+item.amount/100000000)*currencyRate | number: '1.2-2'}}</td>
                 <td class="ellipsis width-10">{{(+item.fee/100000000)*currencyRate | number: '1.1'}}</td>
@@ -56,11 +56,11 @@
         </thead>
         <tbody>
             <tr *ngFor="let item of blocks">
-                <td class="ellipsis width-15"><a href="#" (click)="goToBlock($event, item.id)">{{item.id}}</a></td>
+                <td class="ellipsis width-15"><a [routerLink]="['/block', item.id]">{{item.id}}</a></td>
                 <td class="ellipsis width-15">{{item.height}}</td>
                 <td class="ellipsis width-15">{{item.timestamp | localDate | amDateFormat:'YYYY-MM-DD HH:mm:ss'}}</td>
                 <td class="ellipsis width-10">{{item.transactionsCount}}</td>
-                <td class="ellipsis width-15"><a href="#" (click)="goToAddress($event, item.generator)">{{item.delegate.username}}</a></td>
+                <td class="ellipsis width-15"><a [routerLink]="getAddressLink(item.generator)">{{item.delegate.username}}</a></td>
                 <td class="ellipsis width-15">{{(+item.totalAmount/100000000)*currencyRate | number: '1.2-2'}}</td>
                 <td class="ellipsis width-15">{{(+item.totalForged/100000000)*currencyRate | number: '1.1'}}</td>
             </tr>

--- a/src/app/pages/explorer/explorer.component.ts
+++ b/src/app/pages/explorer/explorer.component.ts
@@ -91,19 +91,8 @@ export class ExplorerComponent implements OnInit, OnDestroy {
     this._marketService.build(this.activeChartTab);
   }
 
-  goToAddress(event, id: string) {
-    event.preventDefault();
-    this.router.navigate(['/address', id]);
-  }
-
-  goToTransaction(event, id: string) {
-    event.preventDefault();
-    this.router.navigate(['/tx', id]);
-  }
-
-  goToBlock(event, id: string) {
-    event.preventDefault();
-    this.router.navigate(['/block', id]);
+  getAddressLink(id: string) {
+    return ['/address', id];
   }
 
   ngOnDestroy() {

--- a/src/app/pages/top-accounts/top-accounts.component.html
+++ b/src/app/pages/top-accounts/top-accounts.component.html
@@ -13,7 +13,7 @@
         <tbody>
             <tr *ngFor="let item of accounts; let i = index;">
                 <td class="ellipsis width-15">{{i + 1}}</td>
-                <td class="ellipsis width-15"><a href="#" (click)="goToAddress($event, item.address)">{{item.address}}</a></td>
+                <td class="ellipsis width-15"><a [routerLink]="['/address', item.address]">{{item.address}}</a></td>
                 <td class="ellipsis width-15">{{(item.balance / 100000000)*currencyValue | number: '1.2-2'}} {{currencyName}}</td>
                 <td class="ellipsis width-15">
                     <span *ngIf="supply">{{(item.balance / supply)*100 | number: '1.2-2'}}%</span>

--- a/src/app/pages/top-accounts/top-accounts.component.ts
+++ b/src/app/pages/top-accounts/top-accounts.component.ts
@@ -51,11 +51,6 @@ export class TopAccountsComponent implements OnInit, OnDestroy {
     );
   }
 
-  goToAddress(event, id: string) {
-    event.preventDefault();
-    this.router.navigate(['/address', id]);
-  }
-
   loadAccounts() {
     this.showLoader = true;
     this._explorerService.getTopAccounts(50, this.accounts.length - 1).subscribe(

--- a/src/app/pages/transaction/transaction.component.html
+++ b/src/app/pages/transaction/transaction.component.html
@@ -13,14 +13,14 @@
                 <div class="ark-summary-item ark-flex-between ark-flex-center" *ngIf="transaction.knownSender">
                     <span class="ark-summary-title">{{ 'GENERAL.INFO.SENDER' | translate }}</span>
                     <div class="ark-summary-data">
-                        <p><a href="#" (click)="goToAddress($event, transaction.senderId)">{{transaction.senderId}}</a></p>
+                        <p><a [routerLink]="getAddressLink(transaction.senderId)">{{transaction.senderId}}</a></p>
                         <p>{{transaction.knownSender.owner}} <span class="opacity">{{transaction.knownSender.description}}</span></p>
                     </div>
                 </div>
                 <div class="ark-summary-item ark-flex-between ark-flex-center" *ngIf="transaction.recipientId">
                     <span class="ark-summary-title">{{ 'GENERAL.INFO.RECIPIENT' | translate }}</span>
                     <div class="ark-summary-data">
-                        <a href="#" (click)="goToAddress($event, transaction.recipientId)">{{transaction.recipientId}}</a>
+                        <a [routerLink]="getAddressLink(transaction.recipientId)">{{transaction.recipientId}}</a>
                     </div>
                 </div>
                 <div class="ark-summary-item ark-flex-between ark-flex-center" *ngIf="transaction.confirmations">
@@ -46,7 +46,7 @@
                 <div class="ark-summary-item ark-flex-between ark-flex-center" *ngIf="transaction.blockid">
                     <span class="ark-summary-title">{{ 'GENERAL.INFO.BLOCK' | translate }}</span>
                     <div class="ark-summary-data">
-                        <a href="#" (click)="goToBlock($event, transaction.blockid)">{{transaction.blockid}}</a>
+                        <a [routerLink]="['/block', transaction.blockid]">{{transaction.blockid}}</a>
                     </div>
                 </div>
             </div>
@@ -69,17 +69,17 @@
                     <tbody>
                         <tr>
                             <td class="ellipsis width-15 ark-tooltip-wrap" [ngClass]="{'ark-transaction': transaction.vendorField}">
-                                <a href="#" (click)="goToTransaction($event, transaction.id)">{{transaction.id | overflowText}}</a>
+                                <a [routerLink]="['/tx', transaction.id]">{{transaction.id | overflowText}}</a>
                                 <span class="ark-tooltip" *ngIf="transaction.vendorField">{{ transaction.vendorField }}</span>
                             </td>
                             <td class="ellipsis width-15">{{transaction.timestamp | localDate | amDateFormat:'YYYY-MM-DD HH:mm:ss'}}</td>
                             <td class="ark-blue-text ellipsis width-15">
-                                <a href="#" *ngIf="transaction.senderDelegate" (click)="goToAddress($event, transaction.senderId)">{{transaction.senderDelegate.username}}</a>
-                                <a href="#" *ngIf="!transaction.senderDelegate && transaction.knownSender" (click)="goToAddress($event, transaction.senderId)">{{transaction.knownSender.owner}}</a>
-                                <a href="#" *ngIf="!transaction.senderDelegate && !transaction.knownSender" (click)="goToAddress($event, transaction.senderId)">{{transaction.senderId | overflowText}}</a>
+                                <a *ngIf="transaction.senderDelegate" [routerLink]="getAddressLink(transaction.senderId)">{{transaction.senderDelegate.username}}</a>
+                                <a *ngIf="!transaction.senderDelegate && transaction.knownSender" [routerLink]="getAddressLink(transaction.senderId)">{{transaction.knownSender.owner}}</a>
+                                <a *ngIf="!transaction.senderDelegate && !transaction.knownSender" [routerLink]="getAddressLink(transaction.senderId)">{{transaction.senderId | overflowText}}</a>
                             </td>
                             <td class="ellipsis width-15">
-                                <a href="#" (click)="goToAddress($event, transaction.recipientId)" *ngIf="!(transaction.asset && transaction.asset.votes || transaction.asset && transaction.asset.signature || transaction.asset && transaction.asset.delegate)">{{transaction.recipientId | overflowText}}</a>
+                                <a [routerLink]="getAddressLink(transaction.recipientId)" *ngIf="!(transaction.asset && transaction.asset.votes || transaction.asset && transaction.asset.signature || transaction.asset && transaction.asset.delegate)">{{transaction.recipientId | overflowText}}</a>
                                 <span *ngIf="transaction.asset && transaction.asset.votes">{{ 'TRANSACTION.ASSET.VOTES' | translate }}</span>
                                 <span *ngIf="transaction.asset && transaction.asset.signature">{{ 'TRANSACTION.ASSET.SIGNATURE' | translate }}</span>
                                 <span *ngIf="transaction.asset && transaction.asset.delegate">{{ 'TRANSACTION.ASSET.DELEGATE' | translate }}</span>

--- a/src/app/pages/transaction/transaction.component.ts
+++ b/src/app/pages/transaction/transaction.component.ts
@@ -47,19 +47,8 @@ export class TransactionComponent implements OnInit,OnDestroy {
     });
   }
 
-  goToAddress(event, id: string) {
-    event.preventDefault();
-    this.router.navigate(['/address', id]);
-  }
-
-  goToBlock(event, id: string) {
-    event.preventDefault();
-    this.router.navigate(['/block', id]);
-  }
-
-  goToTransaction(event, id: string) {
-    event.preventDefault();
-    this.router.navigate(['/tx', id]);
+  getAddressLink(id: string) {
+    return ['/address', id];
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
I noticed that all links to other explorer pages were `onclick`s and then used `router.navigate`. 
This works but does not generate very nice links.
With all these `onclick`-links you can't:
- .. copy them
- .. open them in a new tab (rightclick)
- .. use the middle mouse button to open in a new tab

I replaced all these `onclick` links with `[routerLink]` attributes.

By doing that I used the following logic:
If on the same component a link to a specific route was used more thanc **once** I created a function to get the router link, for links which were only used once I wrote the route link inline (which is the "standard way").