### PR TITLE
Fix voters block (todo in code) & make it look better

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -9,11 +9,13 @@ import { BlockComponent } from './pages/block/block.component';
 import { ActivityGraphComponent } from './pages/activity-graph/activity-graph.component';
 import { DelegateMonitorComponent } from './pages/delegate-monitor/delegate-monitor.component';
 import { TopAccountsComponent } from './pages/top-accounts/top-accounts.component';
+import { VotersComponent } from './pages/address/voters/voters.component';
 
 const appRoutes: Routes = [
   { path: '', component: ExplorerComponent, pathMatch: 'full' },
   { path: 'blocks/:page', component: BlockListComponent },
   { path: 'address/:id', component: AddressComponent },
+  { path: 'address/:id/voters', component: VotersComponent },
   { path: 'tx/:id', component: TransactionComponent },
   { path: 'block/:id', component: BlockComponent },
   { path: 'activityGraph', component: ActivityGraphComponent },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -36,6 +36,8 @@ import { ToggleBackgroundComponent } from './components/header/toggle-background
 import { ThemeService } from './shared/services/theme.service';
 import { LocalStorageService } from './shared/services/local-storage.service';
 import { TogglePriceChartComponent } from './components/header/toggle-price-chart/toggle-price-chart.component';
+import { AddressTableComponent } from './components/address-table/address-table.component';
+import { VotersComponent } from './pages/address/voters/voters.component';
 
 export function HttpLoaderFactory(httpClient: HttpClient) {
   return new TranslateHttpLoader(httpClient, './assets/translate/', '.json');
@@ -63,7 +65,9 @@ export function HttpLoaderFactory(httpClient: HttpClient) {
     DelegatesComponent,
     ScrollTopComponent,
     ToggleBackgroundComponent,
-    TogglePriceChartComponent
+    TogglePriceChartComponent,
+    AddressTableComponent,
+    VotersComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/address-table/address-table.component.html
+++ b/src/app/components/address-table/address-table.component.html
@@ -1,0 +1,34 @@
+<table class="ark-table">
+    <thead>
+        <tr>
+            <th class="ellipsis width-15">{{ 'GENERAL.INFO.RANK' | translate }}</th>
+            <th class="ellipsis width-15">{{ 'GENERAL.INFO.ADDRESS' | translate }}</th>
+            <th class="ellipsis width-15">~{{ 'GENERAL.INFO.BALANCE' | translate }}</th>
+            <th class="ellipsis width-15">{{ (supplyLabel ? supplyLabel : 'GENERAL.INFO.SUPPLY') | translate }}</th>
+            <th class="ellipsis width-15">{{ 'GENERAL.INFO.OWNER' | translate }}</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr *ngFor="let item of accounts; let i = index;">
+            <td class="ellipsis width-15">{{i + 1}}</td>
+            <td class="ellipsis width-15"><a [routerLink]="['/address', item.address]">{{item.address}}</a></td>
+            <td class="ellipsis width-15">{{(item.balance / 100000000)*currencyValue | number: '1.2-2'}} {{currencyName}}</td>
+            <td class="ellipsis width-15">
+                <span *ngIf="supply">{{(item.balance / supply)*100 | number: '1.2-2'}}%</span>
+                <span *ngIf="!supply">0.00%</span>
+            </td>
+            <td class="ellipsis width-15">
+                <span *ngIf="item.knowledge">{{item.knowledge.owner}} <span class="opacity" *ngIf="item.knowledge.description">{{item.knowledge.description}}</span></span>
+                <span *ngIf="!item.knowledge">N/A</span>
+            </td>
+        </tr>
+    </tbody>
+</table>
+<div class="top-loader ark-loader-block" *ngIf="showLoader">
+    <div class="ark-loader-icon"></div>
+    <p>{{ 'GENERAL.LOADING' | translate }}...</p>
+</div>
+<div class="ark-shadowbtn-wrap" *ngIf="isLoadButtonVisible">
+    <button class="ark-shadow-btn" type="button" (click)="loadAccounts()">{{ 'GENERAL.MORE' | translate }}</button>
+    <div class="ark-shadowfor-btn"></div>
+</div>

--- a/src/app/components/address-table/address-table.component.html
+++ b/src/app/components/address-table/address-table.component.html
@@ -28,7 +28,13 @@
     <div class="ark-loader-icon"></div>
     <p>{{ 'GENERAL.LOADING' | translate }}...</p>
 </div>
-<div class="ark-shadowbtn-wrap" *ngIf="isLoadButtonVisible">
+<div *ngIf="areLoadButtonsVisible" class="ark-shadowbtn-wrap" [class.ark-two-buttons]="supportsLoadAll">
+  <div>
     <button class="ark-shadow-btn" type="button" (click)="loadAccounts()">{{ 'GENERAL.MORE' | translate }}</button>
     <div class="ark-shadowfor-btn"></div>
+  </div>
+  <div *ngIf="supportsLoadAll">
+    <button class="ark-shadow-btn" type="button" (click)="loadAllAccounts()">{{ 'GENERAL.LOAD_ALL' | translate }}</button>
+    <div class="ark-shadowfor-btn"></div>
+  </div>
 </div>

--- a/src/app/components/address-table/address-table.component.less
+++ b/src/app/components/address-table/address-table.component.less
@@ -1,11 +1,35 @@
+@import "../../../assets/styles/_variables.less";
+
 .top-loader {
-    margin: -50px 0 30px;
+  margin: 20px 0 30px;
 }
 
 .ark-table {
     margin-bottom: 20px;
 }
 
-.top-loader {
-    margin-top: 20px;
+@media (min-width: @small-mobile) {
+  .ark-two-buttons {
+    width: 520px;
+
+    & > div {
+      float: left;
+      width: 45%;
+      position: relative;
+
+      &:not(:first-child) {
+        margin-left: 5%;
+      }
+    }
+  }
+}
+
+@media (max-width: @small-mobile) {
+  .ark-two-buttons {
+    & > div {
+      &:not(:first-child) {
+        margin-top: 10px;
+      }
+    }
+  }
 }

--- a/src/app/components/address-table/address-table.component.less
+++ b/src/app/components/address-table/address-table.component.less
@@ -1,0 +1,11 @@
+.top-loader {
+    margin: -50px 0 30px;
+}
+
+.ark-table {
+    margin-bottom: 20px;
+}
+
+.top-loader {
+    margin-top: 20px;
+}

--- a/src/app/components/address-table/address-table.component.spec.ts
+++ b/src/app/components/address-table/address-table.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { AddressTableComponent } from './address-table.component';
+
+
+describe('AddressTableComponent', () => {
+  let component: AddressTableComponent;
+  let fixture: ComponentFixture<AddressTableComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ AddressTableComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AddressTableComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/address-table/address-table.component.ts
+++ b/src/app/components/address-table/address-table.component.ts
@@ -1,0 +1,81 @@
+import { Component, OnInit, OnDestroy, Input } from '@angular/core';
+import { Router } from '@angular/router';
+import { Subscription } from 'rxjs/Subscription';
+import { Observable } from 'rxjs/Observable';
+
+import { CurrencyService } from '../../shared/services/currency.service';
+import { ConnectionMessageService } from '../../shared/services/connection-message.service';
+import { initCurrency } from '../../shared/const/currency';
+import {Account} from '../../models/account.model';
+
+@Component({
+  selector: 'ark-address-table',
+  templateUrl: './address-table.component.html',
+  styleUrls: ['./address-table.component.less']
+})
+export class AddressTableComponent implements OnInit, OnDestroy {
+  public accounts: Account[] = [];
+  public currencyName: string = initCurrency.name;
+  public currencyValue: number = initCurrency.value;
+  public supply = 0;
+  public showLoader = false;
+  public isLoadButtonVisible = true;
+
+  @Input()
+  public loadAccountsFunc: (pageSize: number, offSet: number) => Observable<{success: boolean, isLast: boolean, accounts: Account[]}>;
+
+  @Input()
+  public initialNumberOfAccounts = 50;
+
+  @Input()
+  public additionalNumberOfAccounts = 50;
+
+  @Input()
+  public totalSupply: number;
+
+  @Input()
+  public supplyLabel: string;
+
+  private subscription: Subscription;
+  private supplySubscription: Subscription;
+
+  constructor(private router: Router,
+              private _currencyService: CurrencyService,
+              private _connectionService: ConnectionMessageService) {
+  }
+
+  ngOnInit() {
+    this.showLoader = true;
+    this.loadAccountsFunc(this.initialNumberOfAccounts, 0).subscribe(this.loadAccountsCallback);
+    this.subscription = this._currencyService.currencyChosen$.subscribe(currency => {
+      this.currencyName = currency.name;
+      this.currencyValue = currency.value;
+    });
+    if (this.totalSupply) {
+      this.supply = this.totalSupply;
+    } else {
+      this.supplySubscription = this._currencyService.supplyChosen$.subscribe(supply => {
+        this.supply = supply;
+      });
+    }
+  }
+
+  loadAccounts() {
+    this.showLoader = true;
+    this.loadAccountsFunc(this.additionalNumberOfAccounts, this.accounts.length).subscribe(this.loadAccountsCallback);
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+    if (this.supplySubscription) {
+      this.supplySubscription.unsubscribe();
+    }
+  }
+
+  private loadAccountsCallback= (res: {success: boolean, isLast: boolean, accounts: Account[]}): void => {
+    this.accounts = this.accounts.concat(res.accounts || []);
+    this._connectionService.changeConnection(res.success);
+    this.showLoader = !res.success;
+    this.isLoadButtonVisible = !res.isLast;
+  }
+}

--- a/src/app/components/address-table/address-table.component.ts
+++ b/src/app/components/address-table/address-table.component.ts
@@ -6,7 +6,13 @@ import { Observable } from 'rxjs/Observable';
 import { CurrencyService } from '../../shared/services/currency.service';
 import { ConnectionMessageService } from '../../shared/services/connection-message.service';
 import { initCurrency } from '../../shared/const/currency';
-import {Account} from '../../models/account.model';
+import { Account, AccountsResponse } from '../../models/account.model';
+
+export class LoadAccountsResult extends AccountsResponse {
+  public success: boolean;
+  public isLast: boolean;
+  public accounts: Account[];
+}
 
 @Component({
   selector: 'ark-address-table',
@@ -19,16 +25,19 @@ export class AddressTableComponent implements OnInit, OnDestroy {
   public currencyValue: number = initCurrency.value;
   public supply = 0;
   public showLoader = false;
-  public isLoadButtonVisible = true;
+  public areLoadButtonsVisible = true;
 
   @Input()
-  public loadAccountsFunc: (pageSize: number, offSet: number) => Observable<{success: boolean, isLast: boolean, accounts: Account[]}>;
+  public loadAccountsFunc: (pageSize: number, offset: number, loadAll?: boolean) => Observable<LoadAccountsResult>;
 
   @Input()
   public initialNumberOfAccounts = 50;
 
   @Input()
   public additionalNumberOfAccounts = 50;
+
+  @Input()
+  public supportsLoadAll: boolean;
 
   @Input()
   public totalSupply: number;
@@ -60,9 +69,16 @@ export class AddressTableComponent implements OnInit, OnDestroy {
     }
   }
 
-  loadAccounts() {
+  loadAccounts(): void {
     this.showLoader = true;
+    this.areLoadButtonsVisible = false;
     this.loadAccountsFunc(this.additionalNumberOfAccounts, this.accounts.length).subscribe(this.loadAccountsCallback);
+  }
+
+  loadAllAccounts(): void {
+    this.showLoader = true;
+    this.areLoadButtonsVisible = false;
+    this.loadAccountsFunc(0, 0, true).subscribe(this.loadAccountsCallback);
   }
 
   ngOnDestroy() {
@@ -72,10 +88,10 @@ export class AddressTableComponent implements OnInit, OnDestroy {
     }
   }
 
-  private loadAccountsCallback= (res: {success: boolean, isLast: boolean, accounts: Account[]}): void => {
+  private loadAccountsCallback= (res: LoadAccountsResult): void => {
     this.accounts = this.accounts.concat(res.accounts || []);
     this._connectionService.changeConnection(res.success);
     this.showLoader = !res.success;
-    this.isLoadButtonVisible = !res.isLast;
+    this.areLoadButtonsVisible = !res.isLast;
   }
 }

--- a/src/app/pages/address/address.component.html
+++ b/src/app/pages/address/address.component.html
@@ -41,7 +41,7 @@
             </div>
         </div>
         <div *ngIf="addressItem && addressItem.delegate">
-            <div class="ark-section-title">{{ 'ADDRESS.DELEGATE_TITLE' | translate }} <span class="ark-title-username">{{addressItem.delegate.username}}</span></div>
+            <div class="ark-section-title">{{ 'ADDRESS.DELEGATE_TITLE' | translate }} <span class="ark-section-title-addition">{{addressItem.delegate.username}}</span></div>
             <div class="ark-address-summary">
                 <div class="ark-summary ark-summary-delegate">
                     <div class="ark-summary-item ark-flex-between" *ngIf="addressItem.delegate.productivity">
@@ -77,22 +77,24 @@
                 </div>
             </div>
         </div>
-        <!-- Two voters' blocks open&closed -->
-        <!-- TODO: make one block -->
-        <div *ngIf="addressItem && addressItem.voters && addressItem.voters.length">
-            <div class="ark-section-title">{{ 'ADDRESS.VOTERS_TITLE' | translate }} <span class="ark-title-username">{{addressItem.voters.length}}</span></div>
-            <div class="ark-address-summary voters-container" style="display: block;" *ngIf="!openVoters" #voters>
-                <div class="voters-button" (click)="showBlock()"></div>
-                <span class="voters-address" *ngFor="let item of addressItem.voters; let i = index;">
-                    <a [routerLink]="getAddressLink(item.address)" *ngIf="i < votersNumber">{{item.address}} ({{(item.balance / 100000000) | number: '1.2-2'}} ARK)</a>
-                </span>
-            </div>
-            <div class="ark-address-summary voters-container open" style="display: block;" *ngIf="openVoters" #voters>
-                <div class="voters-button" (click)="showBlock()"></div>
-                <span class="voters-address" *ngFor="let item of addressItem.voters"><a [routerLink]="getAddressLink(item.address)">{{item.address}} ({{(item.balance / 100000000) | number: '1.2-2'}} ARK)</a> </span>
-            </div>
+      <div *ngIf="addressItem && addressItem.voters && addressItem.voters.length">
+        <div class="ark-section-title">{{ 'ADDRESS.VOTERS_TITLE' | translate }} <span class="ark-section-title-addition">{{addressItem.voters.length}}</span></div>
+        <div class="ark-address-summary voters-container" [class.open]="areVotersExpanded" style="display: block;" #voters>
+          <i class="voters-button fa" [class.fa-plus-circle]="!areVotersExpanded" [class.fa-minus-circle]="areVotersExpanded" aria-label="false" (click)="areVotersExpanded = !areVotersExpanded"></i>
+          <span class="voters-address" *ngFor="let item of getVoters();">
+            <span>
+                    <a [routerLink]="['/address', item.address]">
+                        <i class="fa fa-user" aria-hidden="true"></i>
+                        {{item.address}}
+                    </a>
+              </span>
+          </span>
         </div>
-        <!-- voters blocks -->
+        <div class="ark-shadowbtn-wrap">
+          <button class="ark-shadow-btn" type="button" [routerLink]="['/address', addressItem.address, 'voters']">{{ 'ADDRESS.VOTER_DETAILS' | translate }}</button>
+          <div class="ark-shadowfor-btn"></div>
+        </div>
+      </div>
         <div class="ark-section-title ">{{ 'ADDRESS.TX_TITLE' | translate }}</div>
         <div class="ark-tab-header ">
             <div class="ark-tab-header-item" [ngClass]="{'active': activeTab === 'all-tr'}" id="all-tr" (click)="getAllTransactions($event)">{{ 'GENERAL.TABS.ALL' | translate }}</div>

--- a/src/app/pages/address/address.component.less
+++ b/src/app/pages/address/address.component.less
@@ -79,7 +79,7 @@
 
   .voters-address {
     font-size: 13px;
-    font-family: 'Avenir', serif;
+    font-family: 'Lucida Console', Monaco, monospace;
     span {
       white-space: nowrap;
     }

--- a/src/app/pages/address/address.component.less
+++ b/src/app/pages/address/address.component.less
@@ -5,11 +5,6 @@
 @import "../../../assets/styles/_elements.less";
 @import "../../../assets/styles/_grid.less";
 
-.ark-title-username {
-  opacity: 0.5;
-  font-size: 18px;
-}
-
 .ark-address-summary {
   margin: 30px 0 50px;
   display: flex;
@@ -75,21 +70,18 @@
     position: absolute;
     width: 35px;
     height: 35px;
+    font-size: 30px;
     right: 7px;
     top: 13px;
     cursor: pointer;
-    transition: 0.3s;
-    background: @button-icon;
+    color: @box-shadow-btn-bg;
   }
 
   .voters-address {
     font-size: 13px;
     font-family: 'Avenir', serif;
-
-    a:before {
-      content: '\2022';
-      display: inline-block;
-      margin: 0 5px;
+    span {
+      white-space: nowrap;
     }
   }
 }

--- a/src/app/pages/address/address.component.ts
+++ b/src/app/pages/address/address.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild, ElementRef, OnDestroy, HostListener, Inject } from '@angular/core';
+import { Component, OnInit, ViewChild, ElementRef, OnDestroy, HostListener, Inject  } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import { Router, ActivatedRoute, Params } from '@angular/router';
 import { ExplorerService } from '../../shared/services/explorer.service';
@@ -28,13 +28,14 @@ export class AddressComponent implements OnInit, OnDestroy {
   public currencyValue: number = initCurrency.value;
   public showLoader = false;
   public showBalanceFooter = false;
-  public openVoters = false;
-  public votersNumber = 4;
   public supply = 0;
+  public voters: Account[];
+  public areVotersExpanded = false;
 
   private _currentAddress = '';
   private subscription: Subscription;
   private supplySubscription: Subscription;
+  private votersNumber = 4;
 
   constructor(
     @Inject(DOCUMENT) private document: Document,
@@ -64,6 +65,10 @@ export class AddressComponent implements OnInit, OnDestroy {
         res => {
           this.addressItem = res.account;
           this._connectionService.changeConnection(res.success);
+          window.scrollTo(0, 0);
+          if (this.addressItem && this.addressItem.voters) {
+            this.voters = this.addressItem.voters.sort((one, two) => two.balance - one.balance);
+          }
         }
       );
 
@@ -102,7 +107,6 @@ export class AddressComponent implements OnInit, OnDestroy {
     } else {
       this.votersNumber = 1;
     }
-
   }
 
   getAllTransactions(event): void {
@@ -141,13 +145,8 @@ export class AddressComponent implements OnInit, OnDestroy {
     );
   }
 
-  showBlock() {
-    // this.votersBlock.nativeElement.classList.toggle('open');
-    this.openVoters = !this.openVoters;
-  }
-
-  getAddressLink(id: string) {
-    return ['/address', id];
+  getVoters() {
+    return this.areVotersExpanded ? this.voters : this.voters.slice(0, this.votersNumber);
   }
 
   ngOnDestroy() {
@@ -155,5 +154,4 @@ export class AddressComponent implements OnInit, OnDestroy {
     this.supplySubscription.unsubscribe();
     this.document.body.classList.remove('extra-footer');
   }
-
 }

--- a/src/app/pages/address/balance-footer/balance-footer.component.less
+++ b/src/app/pages/address/balance-footer/balance-footer.component.less
@@ -15,6 +15,7 @@
     padding: 20px 0;
     font-size: 13px;
     font-family: 'Avenir', serif;
+    z-index: 3;
 
     .ark-balance-address {
         margin:0 20px;

--- a/src/app/pages/address/voters/voters.component.html
+++ b/src/app/pages/address/voters/voters.component.html
@@ -21,6 +21,7 @@
 
   <ark-address-table *ngIf="areVotersVisible"
                      [loadAccountsFunc]="getVoters"
+                     [supportsLoadAll]="true"
                      [totalSupply]="totalVoteBalance"
                      [supplyLabel]="'ADDRESS.VOTES_PERCENTAGE'">
   </ark-address-table>

--- a/src/app/pages/address/voters/voters.component.html
+++ b/src/app/pages/address/voters/voters.component.html
@@ -1,0 +1,27 @@
+<section *ngIf="account">
+  <div class="ark-section-title">
+    {{ 'ADDRESS.VOTERS_TITLE' | translate }}
+    <span class="ark-section-title-addition">
+      {{voters.length}}
+    </span>
+  </div>
+
+  <div class="ark-address-summary">
+    <div class="ark-summary ark-summary-delegate">
+      <div class="ark-summary-item ark-flex-between">
+        <span class="ark-summary-title">{{'GENERAL.INFO.DELEGATE' | translate}}</span>
+        <span class="ark-summary-data">{{account.delegate?.username}}</span>
+      </div>
+      <div class="ark-summary-item ark-flex-between">
+        <span class="ark-summary-title">{{'GENERAL.INFO.DELEGATE' | translate}} {{'GENERAL.INFO.ADDRESS' | translate}}</span>
+        <span class="ark-summary-data"><a [routerLink]="['/address', account.address]">{{account.address}}</a></span>
+      </div>
+    </div>
+  </div>
+
+  <ark-address-table *ngIf="areVotersVisible"
+                     [loadAccountsFunc]="getVoters"
+                     [totalSupply]="totalVoteBalance"
+                     [supplyLabel]="'ADDRESS.VOTES_PERCENTAGE'">
+  </ark-address-table>
+</section>

--- a/src/app/pages/address/voters/voters.component.spec.ts
+++ b/src/app/pages/address/voters/voters.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { VotersComponent } from './voters.component';
+
+
+describe('VotersComponent', () => {
+  let component: VotersComponent;
+  let fixture: ComponentFixture<VotersComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ VotersComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(VotersComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/address/voters/voters.component.ts
+++ b/src/app/pages/address/voters/voters.component.ts
@@ -3,6 +3,7 @@ import { ExplorerService } from '../../../shared/services/explorer.service';
 import { ActivatedRoute, Params } from '@angular/router';
 import { Account } from '../../../models/account.model';
 import { Observable } from 'rxjs/Observable';
+import { LoadAccountsResult } from '../../../components/address-table/address-table.component';
 
 @Component({
   templateUrl: './voters.component.html',
@@ -40,11 +41,11 @@ export class VotersComponent implements OnInit {
     });
   }
 
-  public getVoters = (pageSize: number, offset: number): Observable<any> => {
+  public getVoters = (pageSize: number, offset: number, loadAll?: boolean): Observable<LoadAccountsResult> => {
     return Observable.of({
       success: true,
-      accounts: this.voters.slice(offset, offset + pageSize),
-      isLast: (offset + pageSize) >= this.voters.length
+      accounts: loadAll ? this.voters : this.voters.slice(offset, offset + pageSize),
+      isLast: loadAll || ((offset + pageSize) >= this.voters.length)
     });
   };
 }

--- a/src/app/pages/address/voters/voters.component.ts
+++ b/src/app/pages/address/voters/voters.component.ts
@@ -1,0 +1,50 @@
+import { Component, OnInit } from '@angular/core';
+import { ExplorerService } from '../../../shared/services/explorer.service';
+import { ActivatedRoute, Params } from '@angular/router';
+import { Account } from '../../../models/account.model';
+import { Observable } from 'rxjs/Observable';
+
+@Component({
+  templateUrl: './voters.component.html',
+  styleUrls: ['../address.component.less'],
+  providers: [ExplorerService]
+})
+export class VotersComponent implements OnInit {
+
+  public voters: Account[] = [];
+  public account: Account;
+  public areVotersVisible = true;
+  public totalVoteBalance: number;
+
+  constructor(private _explorerService: ExplorerService,
+              private route: ActivatedRoute) {
+  }
+
+  ngOnInit() {
+    this.route.params.subscribe((params: Params) => {
+      const currentAddress = params['id'];
+
+      this._explorerService.getAccount(currentAddress).subscribe(res => {
+          this.account = res.account;
+          if (!this.account.voters) {
+            this.account.voters = [];
+          }
+
+          this.voters = this.account.voters.sort((one, two) => two.balance - one.balance);
+          this.totalVoteBalance = this.voters.reduce((pv, nv) => Number(pv) + Number(nv.balance), 0);
+          // set to false and then to true again, so the address table is re-rendered
+          this.areVotersVisible = false;
+          window.setTimeout(() => this.areVotersVisible = true);
+        }
+      );
+    });
+  }
+
+  public getVoters = (pageSize: number, offset: number): Observable<any> => {
+    return Observable.of({
+      success: true,
+      accounts: this.voters.slice(offset, offset + pageSize),
+      isLast: (offset + pageSize) >= this.voters.length
+    });
+  };
+}

--- a/src/app/pages/top-accounts/top-accounts.component.html
+++ b/src/app/pages/top-accounts/top-accounts.component.html
@@ -1,37 +1,4 @@
 <section>
     <div class="ark-section-title">{{ 'TOP_ACCOUNTS.TITLE' | translate }}</div>
-    <table class="ark-table">
-        <thead>
-            <tr>
-                <th class="ellipsis width-15">{{ 'GENERAL.INFO.RANK' | translate }}</th>
-                <th class="ellipsis width-15">{{ 'GENERAL.INFO.ADDRESS' | translate }}</th>
-                <th class="ellipsis width-15">~{{ 'GENERAL.INFO.BALANCE' | translate }}</th>
-                <th class="ellipsis width-15">{{ 'GENERAL.INFO.SUPPLY' | translate }}</th>
-                <th class="ellipsis width-15">{{ 'GENERAL.INFO.OWNER' | translate }}</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr *ngFor="let item of accounts; let i = index;">
-                <td class="ellipsis width-15">{{i + 1}}</td>
-                <td class="ellipsis width-15"><a [routerLink]="['/address', item.address]">{{item.address}}</a></td>
-                <td class="ellipsis width-15">{{(item.balance / 100000000)*currencyValue | number: '1.2-2'}} {{currencyName}}</td>
-                <td class="ellipsis width-15">
-                    <span *ngIf="supply">{{(item.balance / supply)*100 | number: '1.2-2'}}%</span>
-                    <span *ngIf="!supply">0.00%</span>
-                </td>
-                <td class="ellipsis width-15">
-                    <span *ngIf="item.knowledge">{{item.knowledge.owner}} <span class="opacity" *ngIf="item.knowledge.description">{{item.knowledge.description}}</span></span>
-                    <span *ngIf="!item.knowledge">N/A</span>
-                </td>
-            </tr>
-        </tbody>
-    </table>
-    <div class="top-loader ark-loader-block" *ngIf="showLoader">
-        <div class="ark-loader-icon"></div>
-        <p>{{ 'GENERAL.LOADING' | translate }}...</p>
-    </div>
-    <div class="ark-shadowbtn-wrap">
-        <button class="ark-shadow-btn" type="button" (click)="loadAccounts()">{{ 'GENERAL.MORE' | translate }}</button>
-        <div class="ark-shadowfor-btn"></div>
-    </div>
+    <ark-address-table [loadAccountsFunc]="explorerService.getTopAccounts"></ark-address-table>
 </section>

--- a/src/app/pages/top-accounts/top-accounts.component.less
+++ b/src/app/pages/top-accounts/top-accounts.component.less
@@ -1,3 +1,0 @@
-.top-loader {
-    margin: -50px 0 30px;
-}

--- a/src/app/pages/top-accounts/top-accounts.component.ts
+++ b/src/app/pages/top-accounts/top-accounts.component.ts
@@ -1,69 +1,17 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
-import { Router } from '@angular/router';
-import { Subscription } from 'rxjs/Subscription';
+import { Component, OnInit } from '@angular/core';
 import { ExplorerService } from '../../shared/services/explorer.service';
-import { CurrencyService } from '../../shared/services/currency.service';
-import { ConnectionMessageService } from '../../shared/services/connection-message.service';
-import { initCurrency } from '../../shared/const/currency';
-import {Account} from '../../models/account.model';
 
 @Component({
   selector: 'ark-top-accounts',
   templateUrl: './top-accounts.component.html',
-  styleUrls: ['./top-accounts.component.less'],
   providers: [ExplorerService]
 })
-export class TopAccountsComponent implements OnInit, OnDestroy {
-  public accounts: Account[] = [];
-  public currencyName: string = initCurrency.name;
-  public currencyValue: number = initCurrency.value;
-  public supply = 0;
-  public showLoader = false;
+export class TopAccountsComponent implements OnInit {
 
-  private subscription: Subscription;
-  private supplySubscription: Subscription;
-
-  constructor(
-    private router: Router,
-    private _explorerService: ExplorerService,
-    private _currencyService: CurrencyService,
-    private _connectionService: ConnectionMessageService
-  ) {
-    this.subscription = _currencyService.currencyChosen$.subscribe(currency => {
-      this.currencyName = currency.name;
-      this.currencyValue = currency.value;
-    });
-    this.supplySubscription = _currencyService.supplyChosen$.subscribe(supply => {
-      this.supply = supply;
-    });
+  constructor(public explorerService: ExplorerService) {
   }
 
   ngOnInit() {
     window.scrollTo(0, 0);
-    this.showLoader = true;
-    this._explorerService.getTopAccounts(50, 0).subscribe(
-      res => {
-        this.accounts = res.accounts;
-        this._connectionService.changeConnection(res.success);
-        this.showLoader = !res.success;
-      }
-    );
   }
-
-  loadAccounts() {
-    this.showLoader = true;
-    this._explorerService.getTopAccounts(50, this.accounts.length - 1).subscribe(
-      res => {
-        this.accounts = this.accounts.concat(res.accounts);
-        this._connectionService.changeConnection(res.success);
-        this.showLoader = !res.success;
-      }
-    );
-  }
-
-  ngOnDestroy() {
-    this.subscription.unsubscribe();
-    this.supplySubscription.unsubscribe();
-  }
-
 }

--- a/src/app/shared/services/explorer.service.ts
+++ b/src/app/shared/services/explorer.service.ts
@@ -9,6 +9,7 @@ import { CONFIG } from '../../app.config';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
 import 'rxjs/Rx';
+import { LoadAccountsResult } from '../../components/address-table/address-table.component';
 
 @Injectable()
 export class ExplorerService {
@@ -48,7 +49,7 @@ export class ExplorerService {
 
   }
 
-  public getTopAccounts = (limit: number, offset: number): Observable<AccountsResponse> => {
+  public getTopAccounts = (limit: number, offset: number): Observable<LoadAccountsResult> => {
     return this.http.get(`${CONFIG.API}/getTopAccounts?limit=${limit}&offset=${offset}`)
       .map((res: Response) => res.json())
       .catch((error: any) => {

--- a/src/app/shared/services/explorer.service.ts
+++ b/src/app/shared/services/explorer.service.ts
@@ -48,13 +48,12 @@ export class ExplorerService {
 
   }
 
-  public getTopAccounts(limit: number, offset: number): Observable<AccountsResponse> {
+  public getTopAccounts = (limit: number, offset: number): Observable<AccountsResponse> => {
     return this.http.get(`${CONFIG.API}/getTopAccounts?limit=${limit}&offset=${offset}`)
       .map((res: Response) => res.json())
       .catch((error: any) => {
         return Observable.throw(error.json());
       });
-
   }
 
   public getTransactionsByAddress(address: any, direction: string): Observable<TransactionsResponse> {

--- a/src/assets/styles/_general.less
+++ b/src/assets/styles/_general.less
@@ -66,3 +66,8 @@
   background: @dark-primary-color;
   color: @dark-body-color;
 }
+
+.ark-section-title-addition {
+  opacity: 0.5;
+  font-size: 18px;
+}

--- a/src/assets/translate/en.json
+++ b/src/assets/translate/en.json
@@ -4,6 +4,7 @@
         "WELL_CONFIRMED": "Well Confirmed",
         "MORE": "More",
         "LOADING": "loading",
+        "LOAD_ALL": "Load All",
         "NEXT_PAGE": "Next page",
         "PREV_PAGE": "Previous page",
         "ACTIVE": "Active",

--- a/src/assets/translate/en.json
+++ b/src/assets/translate/en.json
@@ -68,7 +68,9 @@
         "DELEGATE_TITLE": "Delegate",
         "VOTES_TITLE": "Votes",
         "VOTERS_TITLE": "Voters",
-        "TX_TITLE": "Transactions"
+        "TX_TITLE": "Transactions",
+        "VOTES_PERCENTAGE": "% of votes",
+        "VOTER_DETAILS": "View Voter Details"
     },
     "TRANSACTION": {
         "TITLE": "Transaction",

--- a/src/assets/translate/fr.json
+++ b/src/assets/translate/fr.json
@@ -4,6 +4,7 @@
       "WELL_CONFIRMED": "Confirmé",
       "MORE": "Plus",
       "LOADING": "chargement",
+      "LOAD_ALL": "Charger Tout",
       "NEXT_PAGE": "Page suivante",
       "PREV_PAGE": "Page précédente",
       "ACTIVE": "Active",

--- a/src/assets/translate/fr.json
+++ b/src/assets/translate/fr.json
@@ -68,7 +68,9 @@
       "DELEGATE_TITLE": "Délégué",
       "VOTES_TITLE": "Votes",
       "VOTERS_TITLE": "Électeurs",
-      "TX_TITLE": "Transactions"
+      "TX_TITLE": "Transactions",
+      "VOTES_PERCENTAGE": "% des votes",
+      "VOTER_DETAILS": "Afficher les détails des electeurs"
   },
   "TRANSACTION": {
       "TITLE": "Transaction",


### PR DESCRIPTION
I'ts me again ;)

So there was this todo in the `address.component.html` to mege the two voters block.

First this is how it looked currently (though tbh at my local machine, there's also the balance there):
![image](https://user-images.githubusercontent.com/1086065/33794845-36f14b24-dcd4-11e7-8cc0-9e9d22670df4.png)

Well in my first commit  (8f47b6f) I completed the todo and merged the two blocks into one.
However I also did the following:
- change the icon nex to the address to somethingbetter
- change the expand icon so there is also a "unexpand" icon (see screenshot)
- ordered accounts by balance (so it's more meaningful!)

This is how it looks after my first commit:

![changedlook](https://user-images.githubusercontent.com/1086065/33794873-8951bc46-dcd4-11e7-80d1-83ce93abeec0.PNG)

![changedlook_expanded](https://user-images.githubusercontent.com/1086065/33794874-8cdc6528-dcd4-11e7-83cc-1d2e578c625a.PNG)

However as you can see it still looks not good (at least in my opinion).
So I decided to take the same table as is used for top accounts.
I extracted the table to an own component and changed it so that it's a little more generic and can be used from other places.
Now it looks like this:
![new look](https://user-images.githubusercontent.com/1086065/33794880-b7d51cde-dcd4-11e7-873d-5f32c6172769.PNG)

Note that if you click "Load more" only 50 more voters are loaded each time. Because loading all voters at once into the DOM was slow anyway. However if this functionality is really needed / requested I'd suggest to make another button ("Load all").

Let me know what you think!