### PR TITLE
Add types for explorer api calls

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -3,4 +3,4 @@ export const CONFIG = {
     SOCKET: 'http://193.70.72.90:6002/header',
     GRAPH_SOCKET: 'http://193.70.72.90:6002/activityGraph',
     MONITOR_SOCKET: 'http://193.70.72.90:6002/delegateMonitor'
-}
+};

--- a/src/app/models/account.model.ts
+++ b/src/app/models/account.model.ts
@@ -1,0 +1,24 @@
+import {OwnerInfo} from './owner-info.model';
+import {Delegate} from './delegate.model';
+import {BaseApiResponse} from './api-response.model';
+
+export class Account {
+  public address: string;
+  public balance: number;
+  public delegate: Delegate;
+  public incoming_cnt: number;
+  public knowledge: OwnerInfo;
+  public outgoing_cnt: number;
+  public publicKey: string;
+  public username: string;
+  public voters: Account[];
+  public votes: Account[];
+}
+
+export class AccountResponse extends BaseApiResponse {
+  public account: Account;
+}
+
+export class AccountsResponse extends BaseApiResponse {
+  public accounts: Account[];
+}

--- a/src/app/models/api-response.model.ts
+++ b/src/app/models/api-response.model.ts
@@ -1,0 +1,9 @@
+import {Pagination} from './pagination.model';
+
+export abstract class BaseApiResponse {
+  public success: boolean;
+}
+
+export abstract class BasePaginationApiResponse extends BaseApiResponse {
+  public pagination: Pagination;
+}

--- a/src/app/models/block.model.ts
+++ b/src/app/models/block.model.ts
@@ -1,0 +1,26 @@
+import {Delegate} from './delegate.model';
+import {BaseApiResponse, BasePaginationApiResponse} from './api-response.model';
+
+export class Block {
+  public confirmations: number;
+  public delegate: Delegate;
+  public generator: string; // note: some API calls return a generatorId and some a generator
+  public generatorId: string; // note: some API calls return a generatorId and some a generator
+  public height: number;
+  public id: number;
+  public previousBlock: string;
+  public reward: number;
+  public timestamp: number;
+  public totalAmount: number;
+  public totalFee: number;
+  public totalForged: number;
+  public transactionsCount: number;
+}
+
+export class BlockResponse extends BaseApiResponse {
+  public block: Block;
+}
+
+export class BlocksResponse extends BasePaginationApiResponse {
+  public blocks: Block[];
+}

--- a/src/app/models/delegate.model.ts
+++ b/src/app/models/delegate.model.ts
@@ -1,0 +1,11 @@
+export class Delegate {
+  public username: string;
+  public address: string;
+  public publicKey: string;
+  public productivity: number;
+  public rate: number;
+  public approval: number;
+  public forged: number;
+  public producedblocks: number;
+  public missedblocks: number;
+}

--- a/src/app/models/owner-info.model.ts
+++ b/src/app/models/owner-info.model.ts
@@ -1,0 +1,4 @@
+export class OwnerInfo {
+  public description: string;
+  public owner: string;
+}

--- a/src/app/models/pagination.model.ts
+++ b/src/app/models/pagination.model.ts
@@ -1,0 +1,4 @@
+export class Pagination {
+  public previousPage: number;
+  public nextPage: number;
+}

--- a/src/app/models/transaction.model.ts
+++ b/src/app/models/transaction.model.ts
@@ -1,0 +1,32 @@
+import {Account} from './account.model';
+import {OwnerInfo} from './owner-info.model';
+import {BaseApiResponse} from './api-response.model';
+
+export class Transaction {
+  public amount: number;
+  public asset: TransactionAsset;
+  public blockid: number;
+  public confirmations: number;
+  public fee: number;
+  public id: string;
+  public knownSender: OwnerInfo;
+  public recipientId: string;
+  public senderDelegate: Account;
+  public senderId: string;
+  public timestamp: number;
+  public vendorField: string;
+}
+
+export class TransactionAsset {
+  public delegate: any;
+  public signature: string;
+  public votes: any;
+}
+
+export class TransactionResponse extends BaseApiResponse {
+  public transaction: Transaction;
+}
+
+export class TransactionsResponse extends BaseApiResponse {
+  public transactions: Transaction[];
+}

--- a/src/app/pages/address/address-transactions/address-transactions.component.ts
+++ b/src/app/pages/address/address-transactions/address-transactions.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { Router } from '@angular/router';
+import {Transaction} from '../../../models/transaction.model';
 
 @Component({
   selector: 'ark-address-transactions',
@@ -7,7 +8,7 @@ import { Router } from '@angular/router';
 })
 export class AddressTransactionsComponent implements OnInit {
   @Input() id: string;
-  @Input() items: any[];
+  @Input() items: Transaction[];
   @Input() curName: string;
   @Input() curValue: number;
 

--- a/src/app/pages/address/address.component.ts
+++ b/src/app/pages/address/address.component.ts
@@ -5,6 +5,8 @@ import { ExplorerService } from '../../shared/services/explorer.service';
 import { CurrencyService } from '../../shared/services/currency.service';
 import { ConnectionMessageService } from '../../shared/services/connection-message.service';
 import { initCurrency } from '../../shared/const/currency';
+import {Transaction} from '../../models/transaction.model';
+import {Account} from '../../models/account.model';
 import { Subscription } from 'rxjs/Subscription';
 
 import 'rxjs/add/operator/switchMap';
@@ -19,8 +21,8 @@ export class AddressComponent implements OnInit, OnDestroy {
   @ViewChild('voters') votersBlock: ElementRef;
   @ViewChild('balance') balanceContainer: ElementRef;
 
-  public addressItem: any;
-  public currentTransactions: any[];
+  public addressItem: Account;
+  public currentTransactions: Transaction[];
   public activeTab = 'all-tr';
   public currencyName: string = initCurrency.name;
   public currencyValue: number = initCurrency.value;
@@ -60,7 +62,7 @@ export class AddressComponent implements OnInit, OnDestroy {
 
       this._explorerService.getAccount(this._currentAddress).subscribe(
         res => {
-          this.addressItem = res;
+          this.addressItem = res.account;
           this._connectionService.changeConnection(res.success);
         }
       );

--- a/src/app/pages/block-list/block-list.component.ts
+++ b/src/app/pages/block-list/block-list.component.ts
@@ -4,6 +4,8 @@ import { ExplorerService } from '../../shared/services/explorer.service';
 import { CurrencyService } from '../../shared/services/currency.service';
 import { ConnectionMessageService } from '../../shared/services/connection-message.service';
 import { initCurrency } from '../../shared/const/currency';
+import {Block} from '../../models/block.model';
+import {Pagination} from '../../models/pagination.model';
 import { Subscription } from 'rxjs/Subscription';
 
 @Component({
@@ -13,8 +15,8 @@ import { Subscription } from 'rxjs/Subscription';
   providers: [ExplorerService]
 })
 export class BlockListComponent implements OnInit, OnDestroy {
-  public blocks: any = [];
-  public pagination: any = [];
+  public blocks: Block[] = [];
+  public pagination: Pagination;
   public currencyName: string = initCurrency.name;
   public currencyValue: number = initCurrency.value;
   public showLoader = false;

--- a/src/app/pages/block/block.component.ts
+++ b/src/app/pages/block/block.component.ts
@@ -5,6 +5,8 @@ import { ExplorerService } from '../../shared/services/explorer.service';
 import { CurrencyService } from '../../shared/services/currency.service';
 import { ConnectionMessageService } from '../../shared/services/connection-message.service';
 import { initCurrency } from '../../shared/const/currency';
+import { Transaction } from '../../models/transaction.model';
+import {Block} from '../../models/block.model';
 
 import 'rxjs/add/operator/switchMap';
 
@@ -15,8 +17,8 @@ import 'rxjs/add/operator/switchMap';
   providers: [ExplorerService]
 })
 export class BlockComponent implements OnInit, OnDestroy {
-  public block: any;
-  public transactions: any[] = [];
+  public block: Block;
+  public transactions: Transaction[] = [];
   public currencyName: string = initCurrency.name;
   public currencyValue: number = initCurrency.value;
 

--- a/src/app/pages/explorer/explorer.component.ts
+++ b/src/app/pages/explorer/explorer.component.ts
@@ -6,6 +6,8 @@ import { CoinmarketService } from '../../shared/services/coinmarket.service';
 import { ConnectionMessageService } from '../../shared/services/connection-message.service';
 import { initCurrency } from '../../shared/const/currency';
 import { ThemeService } from '../../shared/services/theme.service';
+import {Transaction} from '../../models/transaction.model';
+import {Block} from '../../models/block.model';
 import { Subscription } from 'rxjs/Subscription';
 
 @Component({
@@ -15,8 +17,8 @@ import { Subscription } from 'rxjs/Subscription';
   providers: [ExplorerService, CoinmarketService]
 })
 export class ExplorerComponent implements OnInit, OnDestroy {
-  public transactions: any;
-  public blocks: any;
+  public transactions: Transaction[];
+  public blocks: Block[];
   public chart: any;
   public isChartVisible: boolean;
   public currency: string = initCurrency.name;

--- a/src/app/pages/top-accounts/top-accounts.component.ts
+++ b/src/app/pages/top-accounts/top-accounts.component.ts
@@ -5,6 +5,7 @@ import { ExplorerService } from '../../shared/services/explorer.service';
 import { CurrencyService } from '../../shared/services/currency.service';
 import { ConnectionMessageService } from '../../shared/services/connection-message.service';
 import { initCurrency } from '../../shared/const/currency';
+import {Account} from '../../models/account.model';
 
 @Component({
   selector: 'ark-top-accounts',
@@ -13,10 +14,10 @@ import { initCurrency } from '../../shared/const/currency';
   providers: [ExplorerService]
 })
 export class TopAccountsComponent implements OnInit, OnDestroy {
-  public accounts: any = [];
+  public accounts: Account[] = [];
   public currencyName: string = initCurrency.name;
   public currencyValue: number = initCurrency.value;
-  public supply: any = 0;
+  public supply = 0;
   public showLoader = false;
 
   private subscription: Subscription;

--- a/src/app/pages/transaction/transaction.component.ts
+++ b/src/app/pages/transaction/transaction.component.ts
@@ -5,6 +5,7 @@ import { ExplorerService } from '../../shared/services/explorer.service';
 import { CurrencyService } from '../../shared/services/currency.service';
 import { ConnectionMessageService } from '../../shared/services/connection-message.service';
 import { initCurrency } from '../../shared/const/currency';
+import {Transaction} from '../../models/transaction.model';
 
 import 'rxjs/add/operator/switchMap';
 
@@ -15,7 +16,7 @@ import 'rxjs/add/operator/switchMap';
   providers: [ ExplorerService ]
 })
 export class TransactionComponent implements OnInit, OnDestroy {
-  public transaction: any;
+  public transaction: Transaction;
   public currencyName: string = initCurrency.name;
   public currencyValue: number = initCurrency.value;
 

--- a/src/app/shared/services/explorer.service.ts
+++ b/src/app/shared/services/explorer.service.ts
@@ -1,3 +1,6 @@
+import {TransactionResponse, TransactionsResponse} from '../../models/transaction.model';
+import {Account, AccountResponse, AccountsResponse} from '../../models/account.model';
+import {BlockResponse, BlocksResponse} from '../../models/block.model';
 import { Injectable } from '@angular/core';
 import { Http, Response } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
@@ -14,13 +17,13 @@ export class ExplorerService {
     private http: Http
   ) { }
 
-  public getLastTransactions(): Observable<any> {
+  public getLastTransactions(): Observable<TransactionsResponse> {
     return this.http.get(`${CONFIG.API}/getLastTransactions`)
       .map((res: Response) => res.json())
       .catch((error: any) => Observable.throw(error.json().error || 'Server error'));
   }
 
-  public getLastBlocks(n?: number): Observable<any> {
+  public getLastBlocks(n?: number): Observable<BlocksResponse> {
     const params = (n >= 0) ? `?n=${n}` : '';
     return this.http.get(`${CONFIG.API}/getLastBlocks${params}`)
       .map((res: Response) => res.json())
@@ -29,16 +32,23 @@ export class ExplorerService {
       });
   }
 
-  public getAccount(address: any): Observable<any> {
+  public getAccount(address: any): Observable<AccountResponse> {
     return this.http.get(`${CONFIG.API}/getAccount?address=${address}`)
       .map((res: Response) => res.json())
+      .map((res: any) => {
+        // note: on this API call the success and the actual data is on the same object...
+        const accountRes = new AccountResponse();
+        accountRes.success = res.success;
+        accountRes.account = res as Account;
+        return accountRes;
+      })
       .catch((error: any) => {
         return Observable.throw(error.json());
       });
 
   }
 
-  public getTopAccounts(limit: number, offset: number): Observable<any> {
+  public getTopAccounts(limit: number, offset: number): Observable<AccountsResponse> {
     return this.http.get(`${CONFIG.API}/getTopAccounts?limit=${limit}&offset=${offset}`)
       .map((res: Response) => res.json())
       .catch((error: any) => {
@@ -47,7 +57,7 @@ export class ExplorerService {
 
   }
 
-  public getTransactionsByAddress(address: any, direction: string): Observable<any> {
+  public getTransactionsByAddress(address: any, direction: string): Observable<TransactionsResponse> {
     const addressParam = direction ? `&direction=${direction}` : '';
     return this.http.get(`${CONFIG.API}/getTransactionsByAddress?address=${address}${addressParam}&limit=50&offset=0`)
       .map((res: Response) => res.json())
@@ -57,7 +67,7 @@ export class ExplorerService {
 
   }
 
-  public getTransaction(id: any): Observable<any> {
+  public getTransaction(id: any): Observable<TransactionResponse> {
     return this.http.get(`${CONFIG.API}/getTransaction?transactionId=${id}`)
       .map((res: Response) => res.json())
       .catch((error: any) => {
@@ -66,7 +76,7 @@ export class ExplorerService {
 
   }
 
-  public getBlock(id: any): Observable<any> {
+  public getBlock(id: any): Observable<BlockResponse> {
     return this.http.get(`${CONFIG.API}/getBlock?blockId=${id}`)
       .map((res: Response) => res.json())
       .catch((error: any) => {
@@ -75,7 +85,7 @@ export class ExplorerService {
 
   }
 
-  public getTransactionsByBlock(id: any): Observable<any> {
+  public getTransactionsByBlock(id: any): Observable<TransactionsResponse> {
     return this.http.get(`${CONFIG.API}/getTransactionsByBlock?blockId=${id}&limit=50&offset=0`)
       .map((res: Response) => res.json())
       .catch((error: any) => {


### PR DESCRIPTION
Had "some" time today and thought I'd address this ;)

I added types for all "normal" API calls and used them in the components.

Even if you'd like to include Ark-ts I thought this will be a good base... since we can probably relatively easy switch out the classes if we decide it.
=> And obviously you can always rejct this elsewise ;)

Note that I did not add any types for the delegate-monitor and for the activity-graph.
As far as I can see the model is not the same for the delegate-monitor (web-sockets) calls.
Should we add another model (other typed classes) there?

Addresses: #43