### PR TITLE
Make toggle switch button look better in dark mode

### DIFF
--- a/src/app/components/header/shared/toggle-switch.styles.less
+++ b/src/app/components/header/shared/toggle-switch.styles.less
@@ -44,6 +44,10 @@
       position: relative;
       cursor: pointer;
       user-select: none;
+      background: darken(@light-secondary-color, 10%);
+      border-radius: 2em;
+      padding: 2px;
+      transition: all .4s ease;
       &:after,
       &:before {
         position: relative;
@@ -55,6 +59,9 @@
 
       &:after {
         left: 0;
+        border-radius: 50%;
+        background: @light-secondary-color;
+        transition: all .2s ease;
       }
 
       &:before {
@@ -62,33 +69,31 @@
       }
     }
 
-    &:checked + .tgl-btn:after {
-      left: 50%;
-    }
-  }
-
-  // themes
-  .tgl-light {
-    + .tgl-btn {
-      background: darken(@light-secondary-color, 10%);
-      border-radius: 2em;
-      padding: 2px;
-      transition: all .4s ease;
-      &:after {
-        border-radius: 50%;
-        background: @light-secondary-color;
-        transition: all .2s ease;
-      }
-    }
-
     &:checked + .tgl-btn {
       background: @switch-btn-checked;
+
+      &:after {
+        left: 50%;
+      }
     }
   }
 }
 
 :host-context(.dark-theme) {
   .tgl-item {
-    color: @dark-header-menu-color
+    color: @dark-header-menu-color;
+    .tgl {
+      + .tgl-btn {
+        background: @dark-toggle-switch-button;
+
+        &:after {
+          background: @dark-toggle-switch-bg;
+        }
+      }
+
+      &:checked + .tgl-btn {
+        background: @switch-btn-checked;
+      }
+    }
   }
 }

--- a/src/app/components/header/toggle-background/toggle-background.component.html
+++ b/src/app/components/header/toggle-background/toggle-background.component.html
@@ -1,7 +1,7 @@
 <li class="ark-menu-item tgl-item">
   <i class="fa fa-sun-o" aria-label="false"></i>
   <div class="tgl-wrapper">
-    <input type="checkbox" id="toggle-background" name="toggle-background" class="tgl tgl-light" (change)="toggleBackground()" [(ngModel)]="isDarkTheme">
+    <input type="checkbox" id="toggle-background" name="toggle-background" class="tgl" (change)="toggleBackground()" [(ngModel)]="isDarkTheme">
     <label for="toggle-background" class="tgl-btn"></label>
   </div>
   <i class="fa fa-moon-o" aria-label="false"></i>

--- a/src/app/components/header/toggle-price-chart/toggle-price-chart.component.html
+++ b/src/app/components/header/toggle-price-chart/toggle-price-chart.component.html
@@ -1,7 +1,7 @@
 <li class="ark-menu-item tgl-item">
   <i class="fa fa-line-chart" aria-label="false"></i>
   <div class="tgl-wrapper">
-    <input type="checkbox" id="toggle-price-chart" name="toggle-price-chart" class="tgl tgl-light" (change)="togglePriceChart()" [(ngModel)]="isVisible">
+    <input type="checkbox" id="toggle-price-chart" name="toggle-price-chart" class="tgl" (change)="togglePriceChart()" [(ngModel)]="isVisible">
     <label for="toggle-price-chart" class="tgl-btn"></label>
   </div>
 </li>

--- a/src/assets/styles/_variables.less
+++ b/src/assets/styles/_variables.less
@@ -161,3 +161,6 @@
 @dark-forger-noforging-color: #B12B2F;
 @dark-forger-awaiting-lost-color: @color-gray-80;
 @dark-forger-missing-color: #AC6838;
+
+@dark-toggle-switch-button: #242424;
+@dark-toggle-switch-bg: #cccccc;


### PR DESCRIPTION
I realized that the toggle switch button looks horrible when disabled in dark-mode - it's way too shiny!

## Before
![image](https://user-images.githubusercontent.com/1086065/34875654-7e31e28e-f79e-11e7-91d1-007c19c26b7c.png)

## Solution 1
Use same "dark" colors as are used for the light mode.
I find it's too dark then (edit: apparently highliy depends on the screen, on my desktop it doesn't look that bad) => not implemented
![darken](https://user-images.githubusercontent.com/1086065/34885914-bfc90952-f7c1-11e7-9f8d-e59bf61b46c8.PNG)

Code:
```
:host-context(.dark-theme) {
  .tgl-item {
    color: @dark-header-menu-color;
    .tgl {
      + .tgl-btn {
        background: darken(@dark-secondary-color, 10%);
        &:after {
          background: @dark-secondary-color;
        }
      }

      &:checked + .tgl-btn {
        background: @switch-btn-checked;
      }
    }
  }
}
```

## Solution 2
Same as solution 1, but use `lighten` instead of darker for the background color.
I find it looks not very good => not implemented
![lighten](https://user-images.githubusercontent.com/1086065/34885943-da5e9fac-f7c1-11e7-9a6a-d0a8d6f92265.PNG)


## Solution 3
Use the color of the header bar as the background and the color of the font as the toggle button.
I like this best => implemented
![new](https://user-images.githubusercontent.com/1086065/34886147-708bb6ea-f7c2-11e7-9f91-76935bb246c8.PNG)

Fixes: #52
