### PR TITLE
Add pagination for transactions & refactor

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -10,11 +10,14 @@ import { ActivityGraphComponent } from './pages/activity-graph/activity-graph.co
 import { DelegateMonitorComponent } from './pages/delegate-monitor/delegate-monitor.component';
 import { TopAccountsComponent } from './pages/top-accounts/top-accounts.component';
 import { VotersComponent } from './pages/address/voters/voters.component';
+import { TransactionListComponent } from './pages/transaction-list/transaction-list.component';
 
 const appRoutes: Routes = [
   { path: '', component: ExplorerComponent, pathMatch: 'full' },
   { path: 'blocks/:page', component: BlockListComponent },
+  { path: 'transactions/:page', component: TransactionListComponent },
   { path: 'address/:id', component: AddressComponent },
+  { path: 'address/:id/transactions/:type/:page', component: AddressComponent },
   { path: 'address/:id/voters', component: VotersComponent },
   { path: 'tx/:id', component: TransactionComponent },
   { path: 'block/:id', component: BlockComponent },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -36,6 +36,9 @@ import { LocalStorageService } from './shared/services/local-storage.service';
 import { TogglePriceChartComponent } from './components/header/toggle-price-chart/toggle-price-chart.component';
 import { AddressTableComponent } from './components/address-table/address-table.component';
 import { VotersComponent } from './pages/address/voters/voters.component';
+import { TransactionTableComponent } from './components/transaction-table/transaction-table.component';
+import { TransactionListComponent } from './pages/transaction-list/transaction-list.component';
+import { PaginationComponent } from './components/pagination/pagination.component';
 
 export function HttpLoaderFactory(httpClient: HttpClient) {
   return new TranslateHttpLoader(httpClient, './assets/translate/', '.json');
@@ -49,6 +52,8 @@ export function HttpLoaderFactory(httpClient: HttpClient) {
     ExplorerComponent,
     CurrencyDropdownComponent,
     BlockListComponent,
+    TransactionListComponent,
+    TransactionTableComponent,
     AddressComponent,
     AddressTransactionsComponent,
     TransactionComponent,
@@ -65,7 +70,8 @@ export function HttpLoaderFactory(httpClient: HttpClient) {
     ToggleBackgroundComponent,
     TogglePriceChartComponent,
     AddressTableComponent,
-    VotersComponent
+    VotersComponent,
+    PaginationComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/pagination/pagination.component.html
+++ b/src/app/components/pagination/pagination.component.html
@@ -1,0 +1,14 @@
+<div class="ark-pagination ark-flex ark-flex-between">
+  <div class="ark-pagination-prev" *ngIf="pagination && pagination.hasNextPage">
+    <i class="fa fa-angle-left angle-icon" aria-hidden="true"></i>
+    <a [routerLink]="getPageLinkFunc(pagination.nextPage)" (click)="changePage()">
+      {{ 'GENERAL.PREV_PAGE' | translate }}
+    </a>
+  </div>
+  <div class="ark-pagination-next" *ngIf="pagination && pagination.hasPreviousPage">
+    <a [routerLink]="getPageLinkFunc(pagination.previousPage)" (click)="changePage()">
+      {{ 'GENERAL.NEXT_PAGE' | translate }}
+    </a>
+    <i class="fa fa-angle-right angle-icon" aria-hidden="true"></i>
+  </div>
+</div>

--- a/src/app/components/pagination/pagination.component.ts
+++ b/src/app/components/pagination/pagination.component.ts
@@ -1,0 +1,77 @@
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { Transaction } from '../../models/transaction.model';
+import { Subscription } from 'rxjs/Subscription';
+import { initCurrency } from '../../shared/const/currency';
+import { CurrencyService } from '../../shared/services/currency.service';
+import { ActivatedRoute, Params, Router } from '@angular/router';
+import { ExplorerService } from '../../shared/services/explorer.service';
+import { Pagination, PaginationResult } from '../../models/pagination.model';
+import { Observable } from 'rxjs/Rx';
+
+@Component({
+  selector: 'ark-pagination',
+  templateUrl: './pagination.component.html'
+})
+export class PaginationComponent implements OnInit, OnDestroy {
+
+  @Input()
+  public getPageLinkFunc: (pageNumber: number) => any[];
+
+  @Input()
+  public getItemsFunc: (offset: number) => Observable<PaginationResult>;
+
+  @Input()
+  public pageSize = 20;
+
+  @Output()
+  public onPageResult: EventEmitter<any> = new EventEmitter<any>();
+
+  @Output()
+  public onChangePage: EventEmitter<number> = new EventEmitter<number>();
+
+  public pagination: Pagination;
+
+  private _currentPage: number;
+  private itemSubscription: Subscription;
+  private routeSubscription: Subscription;
+
+  public constructor(private router: Router,
+                     private route: ActivatedRoute) {
+  }
+
+  public ngOnInit(): void {
+    this.routeSubscription = this.route.params.subscribe((params: Params) => {
+      this.loadItems(+params['page'] || 1);
+    });
+  }
+
+  public ngOnDestroy(): void {
+    if (this.routeSubscription) {
+      this.routeSubscription.unsubscribe();
+    }
+
+    if (this.itemSubscription ) {
+      this.itemSubscription.unsubscribe();
+    }
+  }
+
+  public changePage(newPage: number): void {
+      this.onChangePage.emit(newPage);
+  }
+
+  private loadItems(newPage: number): void {
+    if (this.itemSubscription) {
+      this.itemSubscription.unsubscribe();
+    }
+
+    this._currentPage = newPage;
+
+    const offset = this._currentPage * this.pageSize - this.pageSize;
+
+    this.itemSubscription = this.getItemsFunc(offset).subscribe((res: PaginationResult) => {
+        this.pagination = res.pagination;
+        this.onPageResult.emit(res);
+      }
+    );
+  }
+}

--- a/src/app/components/transaction-table/transaction-table.component.html
+++ b/src/app/components/transaction-table/transaction-table.component.html
@@ -1,0 +1,38 @@
+<div class="ark-section-title">{{ 'EXPLORER.TX_TITLE' | translate }}</div>
+<table class="ark-table">
+  <thead>
+  <tr>
+    <th class="ellipsis width-15">{{ 'GENERAL.INFO.ID' | translate }}</th>
+    <th class="ellipsis width-15">{{ 'GENERAL.INFO.TIMESTAMP' | translate }}</th>
+    <th class="ellipsis width-15">{{ 'GENERAL.INFO.SENDER' | translate }}</th>
+    <th class="ellipsis width-15">{{ 'GENERAL.INFO.RECIPIENT' | translate }}</th>
+    <th class="ellipsis width-20">{{ 'GENERAL.INFO.SMARTBRIDGE' | translate }}</th>
+    <th class="ellipsis width-15">{{ 'GENERAL.INFO.AMOUNT' | translate }} ({{currency}})</th>
+    <th class="ellipsis width-10">{{ 'GENERAL.INFO.FEE' | translate }} ({{currency}})</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr *ngFor="let item of transactions">
+    <td class="ellipsis width-15 ark-tooltip-wrap" [ngClass]="{'ark-transaction': item.vendorField}"><a
+      [routerLink]="['/tx', item.id]">{{item.id | overflowText}}</a>
+      <span class="ark-tooltip" *ngIf="item.vendorField">{{ item.vendorField }}</span>
+    </td>
+    <td class="ellipsis width-15">{{item.timestamp | localDate | amDateFormat:'YYYY-MM-DD HH:mm:ss'}}</td>
+    <td class="ellipsis width-15">
+      <a [routerLink]="getAddressLink(item.senderId)">
+        <span *ngIf="item.senderDelegate">{{item.senderDelegate.username}}</span>
+        <span *ngIf="!item.senderDelegate">{{item.senderId | overflowText}}</span>
+      </a>
+    </td>
+    <td class="ellipsis width-15"><a [routerLink]="getAddressLink(item.recipientId)">{{item.recipientId |
+      overflowText}}</a></td>
+    <td class="ellipsis width-20">{{item.vendorField || ''}}</td>
+    <td class="ellipsis width-15">{{(+item.amount/100000000)*currencyRate | number: '1.2-8'}}</td>
+    <td class="ellipsis width-10">{{(+item.fee/100000000)*currencyRate | number: '1.2-8'}}</td>
+  </tr>
+  </tbody>
+</table>
+<div class="explorer-loader ark-loader-block" *ngIf="showLoader">
+  <div class="ark-loader-icon"></div>
+  <p>{{ 'GENERAL.LOADING' | translate }}...</p>
+</div>

--- a/src/app/components/transaction-table/transaction-table.component.ts
+++ b/src/app/components/transaction-table/transaction-table.component.ts
@@ -1,0 +1,43 @@
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Transaction } from '../../models/transaction.model';
+import { Subscription } from 'rxjs/Subscription';
+import { initCurrency } from '../../shared/const/currency';
+import { CurrencyService } from '../../shared/services/currency.service';
+
+@Component({
+  selector: 'ark-transaction-table',
+  templateUrl: './transaction-table.component.html'
+})
+export class TransactionTableComponent implements OnInit, OnDestroy {
+
+  @Input()
+  public transactions: Transaction[] = [];
+
+  @Input()
+  public showLoader = true;
+
+  public currency: string = initCurrency.name;
+  public currencyRate: number = initCurrency.value;
+
+  private currencySubscription: Subscription;
+
+  public constructor(private _currencyService: CurrencyService) {
+  }
+
+  public ngOnInit(): void {
+    this.currencySubscription = this._currencyService.currencyChosen$.subscribe(currency => {
+      this.currency = currency.name;
+      this.currencyRate = currency.value;
+    });
+  }
+
+  public ngOnDestroy(): void {
+    if (this.currencySubscription) {
+      this.currencySubscription.unsubscribe();
+    }
+  }
+
+  public getAddressLink(id: string): string[] {
+    return ['/address', id];
+  }
+}

--- a/src/app/models/pagination.model.ts
+++ b/src/app/models/pagination.model.ts
@@ -1,4 +1,15 @@
 export class Pagination {
   public previousPage: number;
   public nextPage: number;
+  public hasNextPage: boolean;
+  public hasPreviousPage: boolean;
+
+  public constructor(public currentPage: number) {
+    this.previousPage = currentPage - 1;
+    this.nextPage = currentPage + 1;
+  }
+}
+
+export interface PaginationResult {
+  pagination: Pagination;
 }

--- a/src/app/models/transaction.model.ts
+++ b/src/app/models/transaction.model.ts
@@ -1,6 +1,8 @@
 import {Account} from './account.model';
 import {OwnerInfo} from './owner-info.model';
 import {BaseApiResponse} from './api-response.model';
+import { Pagination, PaginationResult } from './pagination.model';
+import { Delegate } from './delegate.model';
 
 export class Transaction {
   public amount: number;
@@ -11,7 +13,7 @@ export class Transaction {
   public id: string;
   public knownSender: OwnerInfo;
   public recipientId: string;
-  public senderDelegate: Account;
+  public senderDelegate: Delegate;
   public senderId: string;
   public timestamp: number;
   public vendorField: string;
@@ -29,4 +31,16 @@ export class TransactionResponse extends BaseApiResponse {
 
 export class TransactionsResponse extends BaseApiResponse {
   public transactions: Transaction[];
+}
+
+export interface PaginatedTransactions extends PaginationResult {
+  pagination: Pagination;
+  transactions: Transaction[];
+}
+
+export class TransactionRequestParameters {
+  offset?: number;
+  limit?: number;
+  recipientId?: string;
+  senderId?: string;
 }

--- a/src/app/pages/address/address.component.html
+++ b/src/app/pages/address/address.component.html
@@ -95,11 +95,11 @@
           <div class="ark-shadowfor-btn"></div>
         </div>
       </div>
-        <div class="ark-section-title ">{{ 'ADDRESS.TX_TITLE' | translate }}</div>
+        <div class="ark-section-title" #transactions>{{ 'ADDRESS.TX_TITLE' | translate }}</div>
         <div class="ark-tab-header ">
-            <div class="ark-tab-header-item" [ngClass]="{'active': activeTab === 'all-tr'}" id="all-tr" (click)="getAllTransactions($event)">{{ 'GENERAL.TABS.ALL' | translate }}</div>
-            <div class="ark-tab-header-item " [ngClass]="{'active': activeTab === 'sent-tr'}" id="sent-tr" (click)="getSentTransactions($event)">{{ 'GENERAL.TABS.SENT' | translate }}</div>
-            <div class="ark-tab-header-item " [ngClass]="{'active': activeTab === 'received-tr'}" id="received-tr" (click)="getReceivedTransactions($event)">{{ 'GENERAL.TABS.RECEIVED' | translate }}</div>
+            <div class="ark-tab-header-item" [ngClass]="{'active': activeTab === 'all'}" id="all-tr" [routerLink]="getTransactionTypeLink('all')">{{ 'GENERAL.TABS.ALL' | translate }}</div>
+            <div class="ark-tab-header-item " [ngClass]="{'active': activeTab === 'sent'}" id="sent-tr" [routerLink]="getTransactionTypeLink('sent')">{{ 'GENERAL.TABS.SENT' | translate }}</div>
+            <div class="ark-tab-header-item " [ngClass]="{'active': activeTab === 'received'}" id="received-tr" [routerLink]="getTransactionTypeLink('received')">{{ 'GENERAL.TABS.RECEIVED' | translate }}</div>
         </div>
         <div class="ark-loader-block" *ngIf="showLoader">
             <div class="ark-loader-icon"></div>
@@ -111,6 +111,13 @@
                 <ark-address-transactions *ngIf="addressItem" [id]="addressItem.address" [items]="currentTransactions" [curName]="currencyName" [curValue]="currencyValue"></ark-address-transactions>
             </div>
         </div>
+      <ark-pagination *ngIf="addressItem && renderPagination"
+                      [pageSize]="30"
+                      [getPageLinkFunc]="getPageLink"
+                      [getItemsFunc]="currentTransactionsFunc"
+                      (onChangePage)="onChangePage($event)"
+                      (onPageResult)="onPageResult($event)">
+      </ark-pagination>
     </div>
     <ark-balance-footer *ngIf="addressItem" [show]="showBalanceFooter" [address]="addressItem.address" [balance]="addressItem.balance" [curName]="currencyName" [curVal]="currencyValue"></ark-balance-footer>
 </section>

--- a/src/app/pages/explorer/explorer.component.html
+++ b/src/app/pages/explorer/explorer.component.html
@@ -1,82 +1,55 @@
 <section>
-    <div class="ark-graph-wrap" *ngIf="chart && isChartVisible">
-        <div [chart]="chart"></div>
-        <div class="chart-buttons">
-            <span [ngClass]="{'active': activeChartTab === 'day'}" id="day" (click)="updateChart($event)">1d</span>
-            <span [ngClass]="{'active': activeChartTab === 'week'}" id="week" (click)="updateChart($event)">7d</span>
-            <span [ngClass]="{'active': activeChartTab === 'month'}" id="month" (click)="updateChart($event)">1m</span>
-            <span [ngClass]="{'active': activeChartTab === 'quarter'}" id="quarter" (click)="updateChart($event)">3m</span>
-            <span [ngClass]="{'active': activeChartTab === 'year'}" id="year" (click)="updateChart($event)">1y</span>
-            <span [ngClass]="{'active': activeChartTab === 'all'}" id="all" (click)="updateChart($event)">ALL</span>
-        </div>
+  <div class="ark-graph-wrap" *ngIf="chart && isChartVisible">
+    <div [chart]="chart"></div>
+    <div class="chart-buttons">
+      <span [ngClass]="{'active': activeChartTab === 'day'}" id="day" (click)="updateChart($event)">1d</span>
+      <span [ngClass]="{'active': activeChartTab === 'week'}" id="week" (click)="updateChart($event)">7d</span>
+      <span [ngClass]="{'active': activeChartTab === 'month'}" id="month" (click)="updateChart($event)">1m</span>
+      <span [ngClass]="{'active': activeChartTab === 'quarter'}" id="quarter" (click)="updateChart($event)">3m</span>
+      <span [ngClass]="{'active': activeChartTab === 'year'}" id="year" (click)="updateChart($event)">1y</span>
+      <span [ngClass]="{'active': activeChartTab === 'all'}" id="all" (click)="updateChart($event)">ALL</span>
     </div>
-    <div class="ark-section-title">{{ 'EXPLORER.TX_TITLE' | translate }}</div>
-    <table class="ark-table">
-        <thead>
-            <tr>
-                <th class="ellipsis width-15">{{ 'GENERAL.INFO.ID' | translate }}</th>
-                <th class="ellipsis width-15">{{ 'GENERAL.INFO.TIMESTAMP' | translate }}</th>
-                <th class="ellipsis width-15">{{ 'GENERAL.INFO.SENDER' | translate }}</th>
-                <th class="ellipsis width-15">{{ 'GENERAL.INFO.RECIPIENT' | translate }} </th>
-                <th class="ellipsis width-20">{{ 'GENERAL.INFO.SMARTBRIDGE' | translate }}</th>
-                <th class="ellipsis width-15">{{ 'GENERAL.INFO.AMOUNT' | translate }} ({{currency}})</th>
-                <th class="ellipsis width-10">{{ 'GENERAL.INFO.FEE' | translate }} ({{currency}})</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr *ngFor="let item of transactions">
-                <td class="ellipsis width-15 ark-tooltip-wrap" [ngClass]="{'ark-transaction': item.vendorField}"><a [routerLink]="['/tx', item.id]">{{item.id | overflowText}}</a>
-                    <span class="ark-tooltip" *ngIf="item.vendorField">{{ item.vendorField }}</span>
-                </td>
-                <td class="ellipsis width-15">{{item.timestamp | localDate | amDateFormat:'YYYY-MM-DD HH:mm:ss'}}</td>
-                <td class="ellipsis width-15">
-                  <a [routerLink]="getAddressLink(item.senderId)">
-                    <span *ngIf="item.senderDelegate">{{item.senderDelegate.username}}</span>
-                    <span *ngIf="!item.senderDelegate">{{item.senderId | overflowText}}</span>
-                  </a>
-                </td>
-                <td class="ellipsis width-15"><a [routerLink]="getAddressLink(item.recipientId)">{{item.recipientId | overflowText}}</a></td>
-                <td class="ellipsis width-20">{{item.vendorField || ''}}</td>
-                <td class="ellipsis width-15">{{(+item.amount/100000000)*currencyRate | number: '1.2-8'}}</td>
-                <td class="ellipsis width-10">{{(+item.fee/100000000)*currencyRate | number: '1.2-8'}}</td>
-            </tr>
-        </tbody>
-    </table>
-    <div class="explorer-loader ark-loader-block" *ngIf="showTransactionLoader">
-        <div class="ark-loader-icon"></div>
-        <p>{{ 'GENERAL.LOADING' | translate }}...</p>
-    </div>
-    <div class="ark-section-title">{{ 'EXPLORER.BLOCK_TITLE' | translate }}</div>
-    <table class="ark-table">
-        <thead>
-            <tr>
-                <th class="ellipsis width-15">{{ 'GENERAL.INFO.ID' | translate }}</th>
-                <th class="ellipsis width-15">{{ 'GENERAL.INFO.HEIGHT' | translate }}</th>
-                <th class="ellipsis width-15">{{ 'GENERAL.INFO.TIMESTAMP' | translate }}</th>
-                <th class="ellipsis width-10">{{ 'GENERAL.INFO.TRANSACTIONS' | translate }}</th>
-                <th class="ellipsis width-15">{{ 'GENERAL.INFO.GENERATED_BY' | translate }}</th>
-                <th class="ellipsis width-15">{{ 'GENERAL.INFO.AMOUNT' | translate }} ({{currency}})</th>
-                <th class="ellipsis width-15">{{ 'GENERAL.INFO.FORGED' | translate }} ({{currency}})</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr *ngFor="let item of blocks">
-                <td class="ellipsis width-15"><a [routerLink]="['/block', item.id]">{{item.id}}</a></td>
-                <td class="ellipsis width-15">{{item.height}}</td>
-                <td class="ellipsis width-15">{{item.timestamp | localDate | amDateFormat:'YYYY-MM-DD HH:mm:ss'}}</td>
-                <td class="ellipsis width-10">{{item.numberOfTransactions}}</td>
-                <td class="ellipsis width-15"><a [routerLink]="getAddressLink(item.delegate.address)">{{item.delegate.username}}</a></td>
-                <td class="ellipsis width-15">{{(+item.totalAmount/100000000)*currencyRate | number: '1.2-8'}}</td>
-                <td class="ellipsis width-15">{{(+item.totalForged/100000000)*currencyRate | number: '1.2-8'}}</td>
-            </tr>
-        </tbody>
-    </table>
-    <div class="explorer-loader ark-loader-block" *ngIf="showBlockLoader">
-        <div class="ark-loader-icon"></div>
-        <p>{{ 'GENERAL.LOADING' | translate }}...</p>
-    </div>
-    <div class="ark-shadowbtn-wrap">
-        <button class="ark-shadow-btn" type="button" [routerLink]="['/blocks/1']">{{ 'EXPLORER.BUTTON' | translate }}</button>
-        <div class="ark-shadowfor-btn"></div>
-    </div>
+  </div>
+  <ark-transaction-table [transactions]="transactions" [showLoader]="showTransactionLoader"></ark-transaction-table>
+  <div class="ark-shadowbtn-wrap">
+    <button class="ark-shadow-btn" type="button" [routerLink]="['/transactions/1']">
+      {{ 'EXPLORER.SHOW_ALL_TRANSACTIONS_BUTTON' | translate }}
+    </button>
+    <div class="ark-shadowfor-btn"></div>
+  </div>
+  <div class="ark-section-title">{{ 'EXPLORER.BLOCK_TITLE' | translate }}</div>
+  <table class="ark-table">
+    <thead>
+    <tr>
+      <th class="ellipsis width-15">{{ 'GENERAL.INFO.ID' | translate }}</th>
+      <th class="ellipsis width-15">{{ 'GENERAL.INFO.HEIGHT' | translate }}</th>
+      <th class="ellipsis width-15">{{ 'GENERAL.INFO.TIMESTAMP' | translate }}</th>
+      <th class="ellipsis width-10">{{ 'GENERAL.INFO.TRANSACTIONS' | translate }}</th>
+      <th class="ellipsis width-15">{{ 'GENERAL.INFO.GENERATED_BY' | translate }}</th>
+      <th class="ellipsis width-15">{{ 'GENERAL.INFO.AMOUNT' | translate }} ({{currency}})</th>
+      <th class="ellipsis width-15">{{ 'GENERAL.INFO.FORGED' | translate }} ({{currency}})</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr *ngFor="let item of blocks">
+      <td class="ellipsis width-15"><a [routerLink]="['/block', item.id]">{{item.id}}</a></td>
+      <td class="ellipsis width-15">{{item.height}}</td>
+      <td class="ellipsis width-15">{{item.timestamp | localDate | amDateFormat:'YYYY-MM-DD HH:mm:ss'}}</td>
+      <td class="ellipsis width-10">{{item.numberOfTransactions}}</td>
+      <td class="ellipsis width-15"><a
+        [routerLink]="getAddressLink(item.delegate.address)">{{item.delegate.username}}</a></td>
+      <td class="ellipsis width-15">{{(+item.totalAmount/100000000)*currencyRate | number: '1.2-8'}}</td>
+      <td class="ellipsis width-15">{{(+item.totalForged/100000000)*currencyRate | number: '1.2-8'}}</td>
+    </tr>
+    </tbody>
+  </table>
+  <div class="explorer-loader ark-loader-block" *ngIf="showBlockLoader">
+    <div class="ark-loader-icon"></div>
+    <p>{{ 'GENERAL.LOADING' | translate }}...</p>
+  </div>
+  <div class="ark-shadowbtn-wrap">
+    <button class="ark-shadow-btn" type="button" [routerLink]="['/blocks/1']">{{ 'EXPLORER.SHOW_ALL_BLOCKS_BUTTON' | translate }}
+    </button>
+    <div class="ark-shadowfor-btn"></div>
+  </div>
 </section>

--- a/src/app/pages/explorer/explorer.component.ts
+++ b/src/app/pages/explorer/explorer.component.ts
@@ -88,7 +88,7 @@ export class ExplorerComponent implements OnInit, OnDestroy {
   private getLastTransactions() {
     this._explorerService.getLastTransactions().subscribe(
       res => {
-        this.transactions = res;
+        this.transactions = res.transactions;
         this._connectionService.changeConnection(true);
         this.showTransactionLoader = false;
       }

--- a/src/app/pages/transaction-list/transaction-list.component.html
+++ b/src/app/pages/transaction-list/transaction-list.component.html
@@ -1,0 +1,8 @@
+<section>
+  <ark-transaction-table [showLoader]="showLoader" [transactions]="transactions"></ark-transaction-table>
+  <ark-pagination [getPageLinkFunc]="getPageLink"
+                  [getItemsFunc]="getLastTransactions"
+                  (onChangePage)="onChangePage($event)"
+                  (onPageResult)="onPageResult($event)">
+  </ark-pagination>
+</section>

--- a/src/app/pages/transaction-list/transaction-list.component.ts
+++ b/src/app/pages/transaction-list/transaction-list.component.ts
@@ -1,0 +1,42 @@
+import { Component, OnInit} from '@angular/core';
+import { ExplorerService } from '../../shared/services/explorer.service';
+import { Pagination } from '../../models/pagination.model';
+import { PaginatedTransactions, Transaction } from '../../models/transaction.model';
+import { Observable } from 'rxjs/Observable';
+
+@Component({
+  selector: 'ark-block-list',
+  templateUrl: './transaction-list.component.html',
+  providers: [ExplorerService]
+})
+export class TransactionListComponent implements OnInit {
+  public transactions: Transaction[] = [];
+  public pagination: Pagination;
+  public showLoader = false;
+
+  public constructor(private _explorerService: ExplorerService) {
+  }
+
+  public ngOnInit(): void {
+    window.scrollTo(0, 0);
+    this.showLoader = true;
+  }
+
+  public getLastTransactions = (offset?: number): Observable<PaginatedTransactions> => {
+    return this._explorerService.getLastTransactions({offset: offset});
+  }
+
+  public onChangePage = (): void => {
+    this.transactions = [];
+    this.showLoader = true;
+  }
+
+  public onPageResult = (pageResult: PaginatedTransactions): void => {
+    this.transactions = pageResult.transactions;
+    this.showLoader = false;
+  }
+
+  public getPageLink(page: number): any[] {
+    return ['/transactions', page];
+  }
+}

--- a/src/assets/translate/en.json
+++ b/src/assets/translate/en.json
@@ -60,8 +60,9 @@
     },
     "EXPLORER": {
         "TX_TITLE": "Latest Transactions",
+        "SHOW_ALL_TRANSACTIONS_BUTTON": "See All Transactions",
         "BLOCK_TITLE": "Latest Blocks",
-        "BUTTON": "See All Blocks"
+        "SHOW_ALL_BLOCKS_BUTTON": "See All Blocks"
     },
     "ADDRESS": {
         "TITLE": "Address Summary",

--- a/src/assets/translate/fr.json
+++ b/src/assets/translate/fr.json
@@ -62,7 +62,7 @@
   "EXPLORER": {
       "TX_TITLE": "Dernières transactions",
       "BLOCK_TITLE": "Derniers blocs",
-      "BUTTON": "Voir tous les blocs"
+      "SHOW_ALL_BLOCKS_BUTTON": "Voir tous les blocs"
   },
   "ADDRESS": {
       "TITLE": "Résumé adresse",


### PR DESCRIPTION
@boldninja suggested to add pagination to all transactions views - and that's what I did.

I decided to add "real" pagination instead of infinite-scroll ("Load More").
For me the main advantage of this is that the DOM doesn't get too big and too slow and also that you can easily jump back to an very early state by adjusting the pagesize within the URL in your browser.

The look is the same as in the "Show all blocks" view.

However behind the sceners I introduced a `PaginationComponent` which is used by both "Show all transactions" and the address page for "All", "Sent" and "Received" transactions.

The new URL's look like this:

```
// All transactions (own page)
http://localhost:4200/transactions/1

// All address transactions (directly on the address page)
http://localhost:4200/address/DB8LnnQqYvHpG4WkGJ9AJWBYEct7G3yRZg/transactions/all/1

// Sent address transactions (directly on the address page)
http://localhost:4200/address/DB8LnnQqYvHpG4WkGJ9AJWBYEct7G3yRZg/transactions/sent/1

// Received address transactions (directly on the address page)
http://localhost:4200/address/DB8LnnQqYvHpG4WkGJ9AJWBYEct7G3yRZg/transactions/received/1
```

A sample screenshot of the address page:
![image](https://user-images.githubusercontent.com/1086065/34907987-9e9614f6-f888-11e7-86bf-0df1ce2189b6.png)

Note that I refactored all transaction / addres transaction related methods in `ExplorerService` - I could delete quite a lot of duplicated code :)
