### PR TITLE
Show errors if an item cannot be found

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -39,6 +39,7 @@ import { TransactionTableComponent } from './components/transaction-table/transa
 import { TransactionListComponent } from './pages/transaction-list/transaction-list.component';
 import { PaginationComponent } from './components/pagination/pagination.component';
 import { ClipboardComponent } from './components/clipboard/clipboard.component';
+import { ErrorSectionComponent } from './components/error-section/error-section.component';
 
 export function HttpLoaderFactory(httpClient: HttpClient) {
   return new TranslateHttpLoader(httpClient, './assets/translate/', '.json');
@@ -72,7 +73,8 @@ export function HttpLoaderFactory(httpClient: HttpClient) {
     AddressTableComponent,
     VotersComponent,
     PaginationComponent,
-    ClipboardComponent
+    ClipboardComponent,
+    ErrorSectionComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/error-section/error-section.component.html
+++ b/src/app/components/error-section/error-section.component.html
@@ -3,16 +3,6 @@
     <div class="ark-section-title">{{ titleKey | translate }}</div>
     <div class="ark-error-message-block">
       {{ messageKey | translate: messageParams }}
-      <div *ngIf="error" class="ark-error-container">
-        <span class="ark-error-toggle" (click)="showErrorDetails = !showErrorDetails">
-          <i class="fa" [class.fa-plus-circle]="!showErrorDetails" [class.fa-minus-circle]="showErrorDetails" aria-hidden="true"></i>
-          {{ 'GENERAL.DETAILS' | translate}}
-        </span>
-        <div *ngIf="showErrorDetails" class="ark-error-details">
-          {{ error.message }}
-          <pre>{{error.stack}}</pre>
-        </div>
-      </div>
     </div>
   </div>
 </section>

--- a/src/app/components/error-section/error-section.component.html
+++ b/src/app/components/error-section/error-section.component.html
@@ -1,0 +1,18 @@
+<section>
+  <div class="ark-wrap">
+    <div class="ark-section-title">{{ titleKey | translate }}</div>
+    <div class="ark-error-message-block">
+      {{ messageKey | translate: messageParams }}
+      <div *ngIf="error" class="ark-error-container">
+        <span class="ark-error-toggle" (click)="showErrorDetails = !showErrorDetails">
+          <i class="fa" [class.fa-plus-circle]="!showErrorDetails" [class.fa-minus-circle]="showErrorDetails" aria-hidden="true"></i>
+          {{ 'GENERAL.DETAILS' | translate}}
+        </span>
+        <div *ngIf="showErrorDetails" class="ark-error-details">
+          {{ error.message }}
+          <pre>{{error.stack}}</pre>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/app/components/error-section/error-section.component.less
+++ b/src/app/components/error-section/error-section.component.less
@@ -1,0 +1,22 @@
+.ark-error-message-block {
+  border: 1px solid red;
+  color: #717171;
+  margin: 15px 0 30px 0;
+  padding: 20px;
+  font-size: 14px;
+  word-break: break-all;
+
+  .ark-error-container {
+    margin-top: 10px;
+
+    .ark-error-toggle {
+      cursor: pointer;
+    }
+
+    .ark-error-details {
+      font-family: 'Lucida Console', Monaco, monospace;
+      font-size: .8em;
+      padding: 10px;
+    }
+  }
+}

--- a/src/app/components/error-section/error-section.component.less
+++ b/src/app/components/error-section/error-section.component.less
@@ -5,18 +5,4 @@
   padding: 20px;
   font-size: 14px;
   word-break: break-all;
-
-  .ark-error-container {
-    margin-top: 10px;
-
-    .ark-error-toggle {
-      cursor: pointer;
-    }
-
-    .ark-error-details {
-      font-family: 'Lucida Console', Monaco, monospace;
-      font-size: .8em;
-      padding: 10px;
-    }
-  }
 }

--- a/src/app/components/error-section/error-section.component.ts
+++ b/src/app/components/error-section/error-section.component.ts
@@ -16,7 +16,7 @@ export class ErrorSectionComponent {
   public messageParams: Object;
 
   @Input()
-  public error: Error;
-
-  public showErrorDetails: boolean;
+  public set error(value: Error) {
+   console.log(value);
+  }
 }

--- a/src/app/components/error-section/error-section.component.ts
+++ b/src/app/components/error-section/error-section.component.ts
@@ -1,0 +1,22 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'ark-error-section',
+  templateUrl: './error-section.component.html',
+  styleUrls: ['./error-section.component.less']
+})
+export class ErrorSectionComponent {
+  @Input()
+  public titleKey: string;
+
+  @Input()
+  public messageKey: string;
+
+  @Input()
+  public messageParams: Object;
+
+  @Input()
+  public error: Error;
+
+  public showErrorDetails: boolean;
+}

--- a/src/app/models/api-response.model.ts
+++ b/src/app/models/api-response.model.ts
@@ -2,6 +2,7 @@ import {Pagination} from './pagination.model';
 
 export abstract class BaseApiResponse {
   public success: boolean;
+  public error?: any;
 }
 
 export abstract class BasePaginationApiResponse extends BaseApiResponse {

--- a/src/app/models/transaction.model.ts
+++ b/src/app/models/transaction.model.ts
@@ -1,4 +1,3 @@
-import {Account} from './account.model';
 import {OwnerInfo} from './owner-info.model';
 import {BaseApiResponse} from './api-response.model';
 import { Pagination, PaginationResult } from './pagination.model';
@@ -11,10 +10,10 @@ export class Transaction {
   public confirmations: number;
   public fee: number;
   public id: string;
-  public senderPublicKey: string;
   public knownSender: OwnerInfo;
   public recipientId: string;
   public senderDelegate: Delegate;
+  public senderPublicKey: string;
   public senderId: string;
   public timestamp: number;
   public vendorField: string;

--- a/src/app/pages/address/address.component.html
+++ b/src/app/pages/address/address.component.html
@@ -1,4 +1,10 @@
-<section>
+<ark-error-section *ngIf="hasError"
+                   [error]="error"
+                   [titleKey]="'ADDRESS.TITLE'"
+                   [messageKey]="'ADDRESS.ERROR'"
+                   [messageParams]="{address: currentAddress}">
+</ark-error-section>
+<section *ngIf="addressItem">
     <div class="ark-wrap">
         <div class="ark-section-title">{{ 'ADDRESS.TITLE' | translate }}</div>
         <div class="ark-address-summary">

--- a/src/app/pages/address/voters/voters.component.ts
+++ b/src/app/pages/address/voters/voters.component.ts
@@ -25,8 +25,8 @@ export class VotersComponent implements OnInit {
     this.route.params.subscribe((params: Params) => {
       const currentAddress = params['id'];
 
-      this._explorerService.getAccount(currentAddress).subscribe(res => {
-        this.account = res.account
+      this._explorerService.getAccount(currentAddress).subscribe(account => {
+        this.account = account;
 
         this._explorerService.getDelegateByPublicKey(this.account.publicKey).subscribe(res => {
           this.account.delegate = res

--- a/src/app/pages/block/block.component.html
+++ b/src/app/pages/block/block.component.html
@@ -1,3 +1,9 @@
+<ark-error-section *ngIf="erroneousBlockId"
+                   [error]="error"
+                   [titleKey]="'BLOCK.TITLE'"
+                   [messageKey]="'BLOCK.ERROR'"
+                   [messageParams]="{id: erroneousBlockId}">
+</ark-error-section>
 <section *ngIf="block">
     <div class="ark-wrap">
         <div class="ark-section-title">{{ 'BLOCK.TITLE' | translate }}</div>

--- a/src/app/pages/block/block.component.ts
+++ b/src/app/pages/block/block.component.ts
@@ -22,6 +22,9 @@ export class BlockComponent implements OnInit, OnDestroy {
   public currencyName: string = initCurrency.name;
   public currencyValue: number = initCurrency.value;
 
+  public erroneousBlockId: string;
+  public error: Error;
+
   private subscription: Subscription;
 
   constructor(
@@ -40,12 +43,15 @@ export class BlockComponent implements OnInit, OnDestroy {
   ngOnInit() {
     window.scrollTo(0, 0);
     this.route.params.subscribe((params: Params) => {
-      this._explorerService.getBlock(params['id']).subscribe(
-        res => {
-          this.block = res;
+      this.setErrorInfo();
+      this._explorerService.getBlock(params['id']).subscribe(block => {
+          this.block = block;
           this._connectionService.changeConnection(true);
-        }
-      );
+        },
+        (error) => {
+          this._connectionService.changeConnection(false);
+          this.setErrorInfo(params['id'], error);
+        });
 
       this._explorerService.getTransactionsByBlock(params['id']).subscribe(
         res => {
@@ -62,5 +68,10 @@ export class BlockComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.subscription.unsubscribe();
+  }
+
+  private setErrorInfo(id?: string, error?: Error): void {
+    this.erroneousBlockId = id;
+    this.error = error;
   }
 }

--- a/src/app/pages/transaction/transaction.component.html
+++ b/src/app/pages/transaction/transaction.component.html
@@ -1,5 +1,11 @@
+<ark-error-section *ngIf="erroneousTransactionId"
+                   [error]="error"
+                   [titleKey]="'TRANSACTION.TITLE'"
+                   [messageKey]="'TRANSACTION.ERROR'"
+                   [messageParams]="{id: erroneousTransactionId}">
+</ark-error-section>
 <section *ngIf="transaction">
-    <div class="ark-wrap">
+  <div class="ark-wrap">
         <div class="ark-section-title">{{ 'TRANSACTION.TITLE' | translate }}</div>
         <div class="ark-id-block">{{ 'TRANSACTION.ID' | translate }} {{transaction.id}}
             <ark-clipboard [stringToCopy]="transaction.id"></ark-clipboard>

--- a/src/app/pages/transaction/transaction.component.ts
+++ b/src/app/pages/transaction/transaction.component.ts
@@ -19,6 +19,8 @@ export class TransactionComponent implements OnInit, OnDestroy {
   public transaction: Transaction;
   public currencyName: string = initCurrency.name;
   public currencyValue: number = initCurrency.value;
+  public erroneousTransactionId: string;
+  public error: Error;
 
   private subscription: Subscription;
 
@@ -33,17 +35,20 @@ export class TransactionComponent implements OnInit, OnDestroy {
       this.currencyName = currency.name;
       this.currencyValue = currency.value;
     });
-   }
+  }
 
   ngOnInit() {
     window.scrollTo(0, 0);
     this.route.params.subscribe((params: Params) => {
-      this._explorerService.getTransaction(params['id']).subscribe(
-        res => {
+      this.setErrorInfo();
+
+      this._explorerService.getTransaction(params['id']).subscribe(res => {
           this.transaction = res;
           this._connectionService.changeConnection(true);
-        }
-      );
+        },
+        (error) => {
+          this.setErrorInfo(params['id'], error);
+        });
     });
   }
 
@@ -56,4 +61,8 @@ export class TransactionComponent implements OnInit, OnDestroy {
     this.subscription.unsubscribe();
   }
 
+  private setErrorInfo(id?: string, error?: Error): void {
+    this.erroneousTransactionId = id;
+    this.error = error;
+  }
 }

--- a/src/assets/translate/en.json
+++ b/src/assets/translate/en.json
@@ -2,6 +2,7 @@
     "GENERAL": {
         "COPY_CLIPBOARD": "Copy to clipboard",
         "WELL_CONFIRMED": "Well Confirmed",
+        "DETAILS": "Details",
         "MORE": "More",
         "LOADING": "loading",
         "LOAD_ALL": "Load All",
@@ -72,7 +73,8 @@
         "VOTERS_TITLE": "Voters",
         "TX_TITLE": "Transactions",
         "VOTES_PERCENTAGE": "% of votes",
-        "VOTER_DETAILS": "View Voter Details"
+        "VOTER_DETAILS": "View Voter Details",
+        "ERROR": "There was an error getting information for the address '{{ address }}'! Are you sure this is a correct address?"
     },
     "TRANSACTION": {
         "TITLE": "Transaction",
@@ -84,14 +86,16 @@
             "SIGNATURE": "Second signature creation",
             "DELEGATE": "Delegate registration"
         },
-        "NO_TRANSACTIONS": "There are no transactions involving this address"
+      "NO_TRANSACTIONS": "There are no transactions involving this address",
+      "ERROR": "There was an error getting the transaction with the id '{{ id }}'! Are you sure this transaction exists?"
     },
     "BLOCK": {
         "TITLE": "Block",
         "ID": "Block ID",
         "SUMMARY_TITLE": "Summary",
         "TX_TITLE": "Transactions",
-        "PREV_BLOCK": "Previous block"
+        "PREV_BLOCK": "Previous block",
+        "ERROR": "There was an error getting the block with the id '{{ id }}'! Are you sure this blocks exists?"
     },
     "BLOCK_LIST": {
         "TITLE": "Blocks"


### PR DESCRIPTION
Implemented for:

- transactions
- blocks
- addresses

Also refactored the corresponding methods in `explorer-service`  a little.

I implemented it so that the actual error is also displayed on the page (within a collapsible div). So the users can easily send us the real error messages if required.

Collapsed:
![error collapsed](https://user-images.githubusercontent.com/1086065/35062300-2618311e-fbc4-11e7-941d-2ee0586204f5.PNG)

Expanded:
![error expanded](https://user-images.githubusercontent.com/1086065/35062301-2724fed4-fbc4-11e7-8ba0-87f5962c9d2b.PNG)



fixes: #60