### PR TITLE
Fix issue with header covering information

### DIFF
--- a/src/assets/styles/_grid.less
+++ b/src/assets/styles/_grid.less
@@ -45,6 +45,6 @@ section {
 
 @media (max-width: @small-mobile) {
   section {
-    padding: 150px 10px 30px;
+    padding: 220px 10px 30px;
   }
 }


### PR DESCRIPTION
At the moment, the fixed header covers some information on the explorer screens on mobile devices (e.g. top of the front page chart, the delegate monitor title, your the address when looking at your wallet, etc.). For now this can be fixed by increasing the padding a little to account for the larger header, although I don't think this is the proper solution. We should probably look for a different way of showing the information that is currently available in the header, as it takes up a lot of screen space. Some examples of before and after the change can be seen in the attached pictures.

Any suggestions as what would be a good alternative to the current header? We could make the header only show a single row, which can then be expanded to show the rest of the information. What are your thoughts on this or are there already some suggestions for this? Also; this change should solve issue #54 

Delegate screen - before:
![delegate-before](https://user-images.githubusercontent.com/35610748/35171083-cb187954-fd62-11e7-9c41-d59ff9afa4c4.png)

Delegate screen - after:
![delegate-after](https://user-images.githubusercontent.com/35610748/35171087-cc695e68-fd62-11e7-9efc-f5d6eb3c970d.png)

Home screen - before:
![home-before](https://user-images.githubusercontent.com/35610748/35171086-cc2f293c-fd62-11e7-84be-2a545814a4cc.png)

Home screen - after:
![home-after](https://user-images.githubusercontent.com/35610748/35171088-cca0ba34-fd62-11e7-8a07-66d2feb693f7.png)


