### PR TITLE
Fix broken snapshots hardlink

### DIFF
--- a/src/app/components/header/tools-dropdown/tools-dropdown.component.html
+++ b/src/app/components/header/tools-dropdown/tools-dropdown.component.html
@@ -4,6 +4,6 @@
         <li><a [routerLink]="['/topAccounts']" (click)="closeMobileMenu()">{{ 'TOP_ACCOUNTS.TITLE' | translate }}</a></li>
         <li><a [routerLink]="['/activityGraph']" (click)="closeMobileMenu()">{{ 'ACTIVITY_GRAPH.TITLE' | translate }}</a></li>
         <li><a [routerLink]="['/delegateMonitor']" (click)="closeMobileMenu()">{{ 'DELEGATE_MONITOR.TITLE' | translate }}</a></li>
-        <li><a href="https://explorer.ark.io/snapshots/" (click)="closeMobileMenu()">{{ 'HEADER.TOOLS.SNAPSHOTS' | translate }}</a></li>
+        <li><a href="https://snapshots.ark.io/snapshots/" (click)="closeMobileMenu()">{{ 'HEADER.TOOLS.SNAPSHOTS' | translate }}</a></li>
     </ul>
 </li>


### PR DESCRIPTION
The Snapshots menu item on the header dropdown hard links to https://explorer.ark.io/snapshots/ , which has no route. I changed it to https://snapshots.ark.io/snapshots/ which is where the official snapshots are on.