### PR TITLE
Hide "show all" when loading transactions & blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 You can access it at [https://explorer.ark.io/](https://explorer.ark.io/).
 
-The feel of the [old explorer](https://github.com/ArkEcosystem/old-ark-explorer) is retained in the new version, under the hood things are completely revamped. The frontend of the Explorer itself has been redone using AngularJS framework and TypeScript programming language.
+The feel of the [old explorer](https://github.com/ArkEcosystem/old-ark-explorer) is retained in the new version, under the hood things are completely revamped. The frontend of the Explorer itself has been redone using [AngularJS framework](https://angular.io) and [TypeScript programming language](http://www.typescriptlang.org/).
 
 ## Installation
 

--- a/src/app/pages/explorer/explorer.component.html
+++ b/src/app/pages/explorer/explorer.component.html
@@ -11,7 +11,7 @@
     </div>
   </div>
   <ark-transaction-table [transactions]="transactions" [showLoader]="showTransactionLoader"></ark-transaction-table>
-  <div class="ark-shadowbtn-wrap">
+  <div class="ark-shadowbtn-wrap" *ngIf="!showTransactionLoader">
     <button class="ark-shadow-btn" type="button" [routerLink]="['/transactions/1']">
       {{ 'EXPLORER.SHOW_ALL_TRANSACTIONS_BUTTON' | translate }}
     </button>
@@ -47,7 +47,7 @@
     <div class="ark-loader-icon"></div>
     <p>{{ 'GENERAL.LOADING' | translate }}...</p>
   </div>
-  <div class="ark-shadowbtn-wrap">
+  <div class="ark-shadowbtn-wrap" *ngIf="!showBlockLoader">
     <button class="ark-shadow-btn" type="button" [routerLink]="['/blocks/1']">{{ 'EXPLORER.SHOW_ALL_BLOCKS_BUTTON' | translate }}
     </button>
     <div class="ark-shadowfor-btn"></div>


### PR DESCRIPTION
Hey guys :)

Personally, I found this behaviour confusing: when the transactions and blocks are not loaded, I still can click the "show all" button:
![image](https://user-images.githubusercontent.com/10692276/35179862-f73d8602-fdf6-11e7-96da-0ec94b75d7f4.png)

Although it just takes a very short time, I think it's better to hide them until transaction & blocks are loaded :)