### PR TITLE
Fix if there is only "Next Page" and no previous page it's shown on the wrong side

### DIFF
--- a/src/app/components/pagination/pagination.component.html
+++ b/src/app/components/pagination/pagination.component.html
@@ -5,6 +5,8 @@
       {{ 'GENERAL.PREV_PAGE' | translate }}
     </a>
   </div>
+  <div *ngIf="pagination && !pagination.hasNextPage && pagination.hasPreviousPage">
+  </div>
   <div class="ark-pagination-next" *ngIf="pagination && pagination.hasPreviousPage">
     <a [routerLink]="getPageLinkFunc(pagination.previousPage)" (click)="changePage()">
       {{ 'GENERAL.NEXT_PAGE' | translate }}

--- a/src/app/pages/address/address.component.html
+++ b/src/app/pages/address/address.component.html
@@ -115,7 +115,7 @@
                       [pageSize]="30"
                       [getPageLinkFunc]="getPageLink"
                       [getItemsFunc]="currentTransactionsFunc"
-                      (onChangePage)="onChangePage($event)"
+                      (onChangePage)="onChangePage()"
                       (onPageResult)="onPageResult($event)">
       </ark-pagination>
     </div>

--- a/src/app/pages/block-list/block-list.component.html
+++ b/src/app/pages/block-list/block-list.component.html
@@ -35,6 +35,8 @@
                 {{ 'GENERAL.PREV_PAGE' | translate }}
             </a>
         </div>
+      <div *ngIf="pagination && !pagination.previousPage && pagination.nextPage">
+      </div>
         <div class="ark-pagination-next" *ngIf="pagination && pagination.nextPage">
             <a [routerLink]="getPageLink(pagination.nextPage)" (click)="changePage()">
                 {{ 'GENERAL.NEXT_PAGE' | translate }}

--- a/src/app/pages/transaction-list/transaction-list.component.html
+++ b/src/app/pages/transaction-list/transaction-list.component.html
@@ -2,7 +2,7 @@
   <ark-transaction-table [showLoader]="showLoader" [transactions]="transactions"></ark-transaction-table>
   <ark-pagination [getPageLinkFunc]="getPageLink"
                   [getItemsFunc]="getLastTransactions"
-                  (onChangePage)="onChangePage($event)"
+                  (onChangePage)="onChangePage()"
                   (onPageResult)="onPageResult($event)">
   </ark-pagination>
 </section>


### PR DESCRIPTION

This must be on the right:
![image](https://user-images.githubusercontent.com/1086065/35280872-c5969d3e-0051-11e8-8796-cf566116a7ab.png)

Fixed it by ensuring there is always a "left side div", because else `flex-between` moves it to the left side.