### PR TITLE
Toaster styling + clipboard event mgmt

### DIFF
--- a/src/app/components/clipboard/clipboard.component.html
+++ b/src/app/components/clipboard/clipboard.component.html
@@ -1,5 +1,5 @@
 <span class="ark-show-clipboard">
-    <i class="fa fa-clipboard copy-icon opacity" (click)="onCopied()" aria-hidden="true" ngxClipboard [cbContent]="stringToCopy"></i>
+    <i class="fa fa-clipboard copy-icon opacity" aria-hidden="true" ngxClipboard [cbContent]="stringToCopy" (cbOnSuccess)="onCopied()"></i>
     <span class="ark-tooltip ark-clipboard-tooltip">
       {{ 'GENERAL.COPY_CLIPBOARD' | translate }}
     </span>

--- a/src/assets/styles/_general.less
+++ b/src/assets/styles/_general.less
@@ -52,6 +52,22 @@
   position: relative;
 }
 
+.toast-container .toast {
+  background-size: 18px !important;
+  border-radius: 0 !important;
+  font-family: Avenir, serif;
+  font-size: 14px;
+  padding: 10px 10px 10px 50px !important;
+
+  &.toast-success {
+    background-color: @light-primary-color;
+  }
+
+  &.toast-info {
+    background-color: @dark-primary-color;
+  }
+}
+
 @media (max-width: @tablet) {
   .ark-section-title {
     &.ark-topoffset-60 {


### PR DESCRIPTION
- Made toaster messaging consistent with current look-and-feel
- Using built-in success callback for clipboard to display toaster feedback

<img width="529" alt="toaster-success" src="https://user-images.githubusercontent.com/48880/35761536-d91a18c0-0846-11e8-9461-9bdcee6e20d8.png">
<img width="445" alt="toaster-info" src="https://user-images.githubusercontent.com/48880/35761539-e593210a-0846-11e8-88a9-b1df2f6402bd.png">
