### PR TITLE
Build mainnet as prod & fix title

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 language: node_js
 node_js:
   - "8"
-  
+
 addons:
   apt:
     sources:
@@ -24,4 +24,4 @@ script:
   # Use Chromium instead of Chrome.
   - export CHROME_BIN=chromium-browser
   - xvfb-run -a npm run test -- --single-run --no-progress --browser=ChromeNoSandbox
-  - npm run build -- --prod
+  - npm run build-mainnet

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build",
+    "start-mainnet": "ng serve --prod",
+    "build-mainnet": "ng build --prod",
+    "build-devnet": "ng build",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,6 +2,8 @@ import { Component, Renderer2 } from '@angular/core';
 import { CurrencyService } from './shared/services/currency.service';
 import { ThemeService } from './shared/services/theme.service';
 import { TranslateService } from '@ngx-translate/core';
+import { Title } from '@angular/platform-browser';
+import { CONFIG } from './app.config';
 
 @Component({
   selector: 'ark-app',
@@ -14,8 +16,10 @@ export class AppComponent {
     private _currencyService: CurrencyService,
     private _themeService: ThemeService,
     private translate: TranslateService,
-    private renderer: Renderer2
+    private renderer: Renderer2,
+    titleService: Title
   ) {
+    titleService.setTitle(`Ark ${CONFIG.activeNetwork.displayName} | Blockchain Explorer`);
     translate.addLangs(['en', 'ua']);
     translate.setDefaultLang('en');
 

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,7 +1,9 @@
 import { Network, NetworkConfig } from './models/network-config.model';
+import { environment } from '../environments/environment';
 
 const mainNet: Network = {
   name: 'MAINNET',
+  displayName: 'Mainnet',
   node: 'https://explorer.ark.io:8443/api',
   nethash: '6e84d08bd299ed97c212c886c98a57e36545c8f5d645ca7eeae63a8bd62d8988',
   currencies: ['ARK', 'BTC', 'USD', 'EUR', 'GBP', 'CNY', 'KRW'],
@@ -18,6 +20,7 @@ const mainNet: Network = {
 
 const devNet: Network = {
   name: 'DEVNET',
+  displayName: 'Devnet',
   node: 'https://dexplorer.ark.io:8443/api',
   nethash: '578e820911f24e039733b45e4882b73e301f813a0d2c31330dafda84534ffa23',
   currencies: ['DARK'],
@@ -28,6 +31,6 @@ const devNet: Network = {
 };
 
 export const CONFIG: NetworkConfig = {
-  activeNetwork: devNet,
+  activeNetwork: environment.production ? mainNet : devNet,
   availableNetworks: [mainNet, devNet]
 };

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -21,7 +21,7 @@ import { Network } from '../../models/network-config.model';
 export class HeaderComponent implements OnInit, OnDestroy {
   public headerHeight = 0;
   public headerSupply = 0;
-  public headerNethash = CONFIG.activeNetwork.name.toLowerCase();
+  public headerNethash = CONFIG.activeNetwork.displayName;
   public exchangeRate = {};
 
   public openMobileMenu = false;

--- a/src/app/models/network-config.model.ts
+++ b/src/app/models/network-config.model.ts
@@ -5,6 +5,7 @@ export interface NetworkConfig {
 
 export interface Network {
   name: string;
+  displayName: string;
   node: string;
   nethash: string;
   currencies: string[];

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>Ark Mainnet | Blockchain Explorer</title>
+    <title>Ark | Blockchain Explorer</title>
     <base href="/">
 
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
- Fixes the title (was always shown as `Ark Mainnet`)
- Makes it easier for the the deployers to build for the different nets:
 - `npm run build-mainnet` builds for the Mainnet (https://explorer.ark.io) 
 - `npm run build-devnet` builds for the Devnet (https://dexplorer.ark.io) 

The mainnet build also uses the `--prod` flag. I know that you @faustbrian already said once that we don't really need it in another issue. However the size of build files significantly smaller (~2MB vs ~6MB (the size of all js files)) and I believe it's also faster in execution, so I think it would be a good idea to deploy Ark as `prod` and Dark as `dev`.

The "deployers" can now simply run both commands, without having to change something in the `app.config.ts` file.