### PR TITLE
Make mobile header look better

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -42,6 +42,7 @@ import { ErrorSectionComponent } from './components/error-section/error-section.
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ToastrModule } from 'ngx-toastr';
 import { ExplorerService } from './shared/services/explorer.service';
+import { HeaderDataComponent } from './components/header/header-data/header-data.component';
 
 export function HttpLoaderFactory(httpClient: HttpClient) {
   return new TranslateHttpLoader(httpClient, './assets/translate/', '.json');
@@ -76,7 +77,8 @@ export function HttpLoaderFactory(httpClient: HttpClient) {
     VotersComponent,
     PaginationComponent,
     ClipboardComponent,
-    ErrorSectionComponent
+    ErrorSectionComponent,
+    HeaderDataComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/header/header-data/header-data.component.html
+++ b/src/app/components/header/header-data/header-data.component.html
@@ -1,0 +1,24 @@
+<div class="ark-header-data ark-flex-center">
+  <div class="ark-data-item">
+    <span class="ark-item-index" *ngIf="headerHeight">
+      <span class="ark-index-title"> {{ 'GENERAL.INFO.HEIGHT' | translate}}:</span>
+      <span class="ark-index-data">{{headerHeight}}</span>
+    </span>
+    <span class="ark-item-index ark-item-nethash" *ngIf="headerNethash">
+      <span class="ark-index-title"> {{ 'GENERAL.INFO.NETHASH' | translate}}:</span>
+      <span class="ark-index-data">{{headerNethash}}</span>
+    </span>
+    <span class="ark-item-index" *ngIf="headerSupply">
+      <span class="ark-index-title"> {{ 'GENERAL.INFO.SUPPLY' | translate}}:</span>
+      <span class="ark-index-data">{{headerSupply}}</span>
+    </span>
+  </div>
+  <div *ngFor="let currency of currencies">
+    <div class="ark-data-item" *ngIf="currency.value">
+      <span class="ark-item-index">
+        <span class="ark-index-title"> ARK/{{ currency.name }}:</span>
+        <span class="ark-index-data">{{ currency.value | number: (currency.name === 'BTC' ? '1.8-8' : '1.2-2') }}</span>
+      </span>
+    </div>
+  </div>
+</div>

--- a/src/app/components/header/header-data/header-data.component.less
+++ b/src/app/components/header/header-data/header-data.component.less
@@ -1,0 +1,50 @@
+@import "../../../../assets/styles/_variables.less";
+
+.ark-header-data {
+  font-size: 11px;
+  color: @light-body-color;
+  font-family: 'Comfortaa-Regular', serif;
+  align-items: center;
+  background: @light-subheader-bg;
+  height: 40px;
+  padding: 0 20px;
+  .ark-data-item {
+    text-align: left;
+    .ark-item-nethash .ark-index-data {
+      text-transform: capitalize;
+    }
+    .ark-item-index {
+      margin-right: 15px;
+      overflow: hidden;
+      white-space: nowrap;
+      .ark-index-title {
+        font-family: 'Comfortaa-Bold', serif;
+        color: @light-subheader-label-color;
+      }
+      .ark-index-data {
+        color: @light-subheader-text-color;;
+        padding-left: 5px;
+      }
+    }
+  }
+
+  @media (max-width: @tablet) {
+    height: auto;
+    padding: 10px 10px;
+    display: block;
+  }
+}
+
+:host-context(.dark-theme) {
+  .ark-header-data {
+    background: @dark-subheader-bg;
+    color: @dark-body-color;
+
+    .ark-data-item .ark-item-index .ark-index-title {
+      color: @dark-subheader-label-color;
+    }
+    .ark-data-item .ark-item-index .ark-index-data {
+      color: @dark-subheader-text-color;
+    }
+  }
+}

--- a/src/app/components/header/header-data/header-data.component.ts
+++ b/src/app/components/header/header-data/header-data.component.ts
@@ -1,0 +1,21 @@
+import { Component, Input } from '@angular/core';
+
+
+@Component({
+  selector: 'ark-header-data',
+  templateUrl: './header-data.component.html',
+  styleUrls: ['./header-data.component.less']
+})
+export class HeaderDataComponent {
+  @Input()
+  public headerHeight: number;
+
+  @Input()
+  public headerSupply: number;
+
+  @Input()
+  public headerNethash: string;
+
+  @Input()
+  public currencies: string[];
+}

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -1,7 +1,8 @@
 <div class="fixed-header">
     <div class="ark-wrap">
         <header>
-            <a class="ark-logo" routerLink="/" (click)="closeMobileMenu()"></a>
+          <a class="ark-logo" routerLink="/" (click)="closeMobileMenu()"></a>
+          <span class="ark-mobile-header-title">Ark {{headerNethash}}</span>
             <div class="ark-header-items ark-flex-center" [ngClass]="{'open': openMobileMenu}">
                 <div class="ark-search-wrap">
                     <input class="ark-text-field ark-search-field" type="search" [(ngModel)]="searchQuery" placeholder="{{ 'HEADER.SEARCH' | translate}}" (keypress)="startSearch($event)" />
@@ -16,33 +17,20 @@
                         <ark-tools-dropdown (openMobMenu)="closeMobileMenu($event)"></ark-tools-dropdown>
                     </ul>
                 </nav>
+              <ark-header-data class="ark-inline-header-data"
+                               [currencies]="currencies"
+                               [headerHeight]="headerHeight"
+                               [headerNethash]="headerNethash"
+                               [headerSupply]="headerSupply">
+              </ark-header-data>
             </div>
             <div class="ark-menu-btn" (click)="showMobileMenu()"></div>
         </header>
-        <div class="connection-message" *ngIf="!connection"><i class="fa fa-clock-o" aria-hidden="true"></i>Updating data. Please, wait or refresh this page in 15 seconds.</div>
-        <div class="ark-header-data ark-flex-center">
-            <div class="ark-data-item">
-                <span class="ark-item-index" *ngIf="headerHeight">
-                    <span class="ark-index-title"> {{ 'GENERAL.INFO.HEIGHT' | translate}}:</span>
-                    <span class="ark-index-data">{{headerHeight}}</span>
-                </span>
-                <span class="ark-item-index ark-item-nethash" *ngIf="headerNethash">
-                    <span class="ark-index-title"> {{ 'GENERAL.INFO.NETHASH' | translate}}:</span>
-                    <span class="ark-index-data">{{headerNethash}}</span>
-                </span>
-                <span class="ark-item-index" *ngIf="headerSupply">
-                    <span class="ark-index-title"> {{ 'GENERAL.INFO.SUPPLY' | translate}}:</span>
-                    <span class="ark-index-data">{{headerSupply}}</span>
-                </span>
-            </div>
-            <div *ngFor="let currency of currencies">
-                <div class="ark-data-item" *ngIf="currency.value">
-                    <span class="ark-item-index">
-                        <span class="ark-index-title"> ARK/{{ currency.name }}:</span>
-                        <span class="ark-index-data">{{ currency.value | number: (currency.name === 'BTC' ? '1.8-8' : '1.2-2') }}</span>
-                    </span>
-                </div>
-            </div>
-        </div>
+        <ark-header-data class="ark-standalone-header-data"
+                         [currencies]="currencies"
+                         [headerHeight]="headerHeight"
+                         [headerNethash]="headerNethash"
+                         [headerSupply]="headerSupply">
+        </ark-header-data>
     </div>
 </div>

--- a/src/app/components/header/header.component.less
+++ b/src/app/components/header/header.component.less
@@ -22,6 +22,9 @@ header {
   background: @light-header-bg;
   position: relative;
   z-index: 1;
+  .ark-mobile-header-title {
+    display: none;
+  }
   .box-shadow(0 2px 14px 0 @box-shadow-color);
   .ark-logo {
     margin-right: 25px;
@@ -47,6 +50,12 @@ header {
   }
 
   @media (max-width: @tablet) {
+    .ark-mobile-header-title {
+      font-family: 'Comfortaa-Regular', serif;
+      width: 100%;
+      text-align: left;
+      display: inline-block;
+    }
     height: 60px;
     // position: fixed;
     top: 0;
@@ -55,7 +64,7 @@ header {
     background-color: @light-header-bg;
     z-index: 3;
     .ark-logo {
-      width: 60px;
+      width: 78px;
       height: 60px;
     }
     .ark-header-items {
@@ -68,12 +77,8 @@ header {
       left: -120%;
       width: 100%;
       .transition(all .5s);
-      padding: 10px;
       &.open {
         left: 0;
-      }
-      .ark-header-data {
-        margin: 0 auto;
       }
       nav {
         display: block;
@@ -91,70 +96,26 @@ header {
   }
 
   @media (max-width: @small-mobile) {
-  .ark-header-items {
-    box-sizing: border-box;
-      .ark-header-data {
-        display: block;
-        .ark-data-item {
-          font-size: 13px;
-          margin-bottom: 10px;
-        }
-      }
+    .ark-header-items {
+      box-sizing: border-box;
     }
   }
 }
 
+.ark-inline-header-data {
+  display: none;
+}
 
-.ark-header-data {
-  font-size: 11px;
-  color: @light-body-color;
-  font-family: 'Comfortaa-Regular', serif;
-  align-items: center;
-  background: @light-subheader-bg;
-  height: 40px;
-  padding: 0 20px;
-  .ark-data-item {
-    .ark-item-nethash .ark-index-data {
-      text-transform: capitalize;
-    }
-    .ark-item-index {
-      margin-right: 30px;
-      overflow: hidden;
-      white-space: nowrap;
-      .ark-index-title {
-        font-family: 'Comfortaa-Bold', serif;
-        color: @light-subheader-label-color;
-      }
-      .ark-index-data {
-        color: @light-subheader-text-color;;
-        padding-left: 5px;
-      }
-    }
+@media (max-width: @tablet) {
+  .ark-standalone-header-data {
+    display: none;
   }
-
-  @media (max-width: @small-mobile) {
-    height: auto;
-    padding: 10px 10px;
+  .ark-inline-header-data {
     display: block;
   }
 }
 
-.connection-message {
-  background: @color-gray-10;
-  text-align: center;
-  font-size: 13px;
-  font-family: 'Avenir', serif;
-  padding: 15px 0;
-
-  i {
-    margin-right: 10px;
-  }
-}
-
 :host-context(.dark-theme) {
-  .connection-message {
-    background: @color-gray-80;
-  }
   header {
     background: @dark-header-bg;
     box-shadow: none;

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -26,7 +26,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
 
   public openMobileMenu = false;
   public searchQuery = '';
-  public connection = true;
 
   private _timer: any = null;
   private _network: Network = CONFIG.activeNetwork;

--- a/src/assets/styles/_grid.less
+++ b/src/assets/styles/_grid.less
@@ -45,6 +45,6 @@ section {
 
 @media (max-width: @small-mobile) {
   section {
-    padding: 220px 10px 30px;
+    padding: 70px 10px 30px;
   }
 }


### PR DESCRIPTION
Personally I found the mobile header very very ugly and it needed waaaaaay to much space.

So I tackled this and after some hard fights with the [CSS](https://imgur.com/gallery/Q3cUg29) I managed to do what I wanted. I basically don't display the header data anymore by default, but it's still displayed when the menu is opened.

Before:
![image](https://user-images.githubusercontent.com/1086065/35827480-84057ab4-0abc-11e8-8b6a-b0a4ba5c72c8.png)

After:
![image](https://user-images.githubusercontent.com/1086065/35827507-92ac5be6-0abc-11e8-8516-f61326a8dd9b.png)

After (menu open):
![image](https://user-images.githubusercontent.com/1086065/35827525-9bd76a76-0abc-11e8-87f8-679d98c7bc1e.png)

Since I did quite some stuff with CSS it would be nice if someone other could test in various resolutions and see if anything looks strange.
