### PR TITLE
Don't truncate vendorfield on desktop

### DIFF
--- a/src/components/tables/Transactions.vue
+++ b/src/components/tables/Transactions.vue
@@ -26,7 +26,7 @@
           <wallet-link :address="transaction.recipientId"></wallet-link>
         </td>
         <td class="p-4 text-right border-none hidden lg:table-cell">
-          {{ transaction.vendorField }}
+          {{ truncate(transaction.vendorField || '', 35) }}
         </td>
         <td class="p-4 pr-10 md:pr-4 text-right border-none">
           {{ readableCrypto(transaction.amount) }}

--- a/src/components/tables/Transactions.vue
+++ b/src/components/tables/Transactions.vue
@@ -26,7 +26,7 @@
           <wallet-link :address="transaction.recipientId"></wallet-link>
         </td>
         <td class="p-4 text-right border-none hidden lg:table-cell">
-          {{ truncate(transaction.vendorField || '') }}
+          {{ transaction.vendorField }}
         </td>
         <td class="p-4 pr-10 md:pr-4 text-right border-none">
           {{ readableCrypto(transaction.amount) }}


### PR DESCRIPTION
Truncated vendorfields look silly on the desktop:

![before](https://i.gyazo.com/e629a56814c80f5351dc587b0b9497f3.png)

I know that hovering the transaction id shows the full vendorfield in a tooltip, but I thought displaying the full field was more aesthetically pleasing:

![after](https://i.gyazo.com/da19a38a263d7956ea1e2e7de157d4fc.png)

Could also only truncate vendorfields longer than around 40 chars. 