### PR TITLE
Improved dark theme

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -51,10 +51,10 @@
   --color-theme-text-primary: #ffffff;
   --color-theme-text-secondary: #a1a2a6;
   --color-theme-text-content: #a1a2a6;
-  --color-theme-text-placeholder: #4e505a;
+  --color-theme-text-placeholder: #9598ab;
   --theme-shadow: none;
   --theme-table-hover-shadow: none;
-  --theme-border: #25262c;
+  --theme-border: #444651;
   --theme-border-secondary: #25262c;
   --nav-background: #2a2b31;
   --nav-border: #282a30;


### PR DESCRIPTION
Slight improvement to the current dark theme, as the placeholder text and borders were very difficult to see on my screen.

Before:
![heading-before](https://user-images.githubusercontent.com/35610748/36046648-eb9ba944-0dd9-11e8-8ab9-8ad92f88a30c.png)

After:
![heading-after](https://user-images.githubusercontent.com/35610748/36046646-eb675ce8-0dd9-11e8-8801-8fc3aac59fb5.png)

