### PR TITLE
Remove "next" when no further transactions are available

### DIFF
--- a/src/pages/Wallet/Transactions.vue
+++ b/src/pages/Wallet/Transactions.vue
@@ -8,7 +8,7 @@
       <div class="sm:hidden">
         <table-transactions-mobile :transactions="transactions"></table-transactions-mobile>
       </div>
-      <paginator :start="+this.page"></paginator>
+      <paginator :start="+this.page" :count="totalTransactions"></paginator>
     </section>
   </div>
 </template>
@@ -18,10 +18,14 @@ import WalletService from '@/services/wallet'
 import TransactionService from '@/services/transaction'
 
 export default {
-  data: () => ({ transactions: [] }),
+  data: () => ({ 
+    totalTransactions: 0,
+    transactions: [] 
+  }),
 
   created() {
     this.$on('paginatorChanged', page => this.changePage(page))
+    this.getTotalTransactions()
   },
 
   beforeRouteEnter (to, from, next) {
@@ -60,6 +64,29 @@ export default {
       if (!transactions) return
 
       this.transactions = transactions
+    },
+
+    getTotalTransactions() {
+      if (this.type === 'sent' || this.type === 'all') {
+        this.getSentCount()
+      }
+      if (this.type === 'received' || this.type === 'all') {
+        this.getReceivedCount()
+      }
+    },
+
+    getSentCount() {
+      WalletService
+        .find(this.address)
+        .then(wallet => TransactionService.sendByAddressCount(wallet.address))
+        .then(response => (this.totalTransactions += Number(response)))
+    },
+    
+    getReceivedCount() {
+      WalletService
+        .find(this.address)
+        .then(wallet => TransactionService.receivedByAddressCount(wallet.address))
+        .then(response => (this.totalTransactions += Number(response)))
     },
 
     changePage(page) {


### PR DESCRIPTION
When looking at the list of transactions in a wallet, you were able to keep pressing the "next" button even though there were no further transactions (and you were shown a "loading.." text even though it will never load any transactions, which is confusion). This PR adds a "totalTransactions" property that is passed to the paginator to ensure that the next button will be hidden on the last transaction page.

Question regarding this PR: I'm using two functions to retrieve the amount of sent/received transactions, but those are also calculated in `/src/components/wallet/Details.vue` as part of the wallet screen. Is there a way in which we can pass these values along as a property of some sort? As that would remove the need to make the same call again on the transactions page.