### PR TITLE
Also show red/green color on transactions overview

### DIFF
--- a/src/components/tables/Transactions.vue
+++ b/src/components/tables/Transactions.vue
@@ -32,7 +32,10 @@
 
     <table-column show="amount" label="Amount (ARK)" header-class="right-header-end-cell md:pr-4" cell-class="right-end-cell md:pr-4">
       <template slot-scope="row">
-        {{ readableCrypto(row.amount) }}
+        <span :class="{
+          'text-red': row.senderId === $route.params.address,
+          'text-green': row.recipientId === $route.params.address,
+        }">{{ readableCrypto(row.amount) }}</span>
       </template>
     </table-column>
 


### PR DESCRIPTION
This enables the red/green colors in the transaction overview that you see when you've clicked on the "Show more" button in a wallet.

Is it also an idea to add the red / green colors to the tables on mobile? I find that it makes it much easier to see whether a transaction was sent / received that way, but I'm not sure if it will result in a negative UX as you don't have rows in the mobile view.