### PR TITLE
Always use 2 digits for fiat currencies

### DIFF
--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -64,6 +64,7 @@ const methods = {
         maximumFractionDigits: 8,
       })
       : value.toLocaleString(undefined, {
+        minimumFractionDigits: 2,
         maximumFractionDigits: 2,
       })
   },


### PR DESCRIPTION
With the fiat currencies, there was a maximum of 2 digits, but no minimum. As a result, values such as 4.00 or 4.10 would be shown as 4 and 4.1 instead (see example images) which looked a bit odd.

![ark-4](https://user-images.githubusercontent.com/35610748/36115589-d01c8af6-1033-11e8-8512-3542d04dff72.png)
![ark-33](https://user-images.githubusercontent.com/35610748/36115590-d049d43e-1033-11e8-87bd-1d1d528519e2.png)

This PR simply adds a minimum property, so the currency values are also shown with 2 digits in aforementioned cases.

