### PR TITLE
Hide fee table heading when column is hidden

### DIFF
--- a/src/components/tables/Transactions.vue
+++ b/src/components/tables/Transactions.vue
@@ -36,7 +36,7 @@
       </template>
     </table-column>
 
-    <table-column show="fee" label="Fee (ARK)" header-class="right-header-end-cell" cell-class="right-end-cell hidden md:table-cell">
+    <table-column show="fee" label="Fee (ARK)" header-class="right-header-end-cell hidden md:table-cell" cell-class="right-end-cell hidden md:table-cell">
       <template slot-scope="row">
         {{ readableCrypto(row.fee) }}
       </template>


### PR DESCRIPTION
On smaller screens, the "fee" column was hidden, but not its heading (see attached images). This PR makes sure that also the heading gets hidden

Before:
![before-hiding](https://user-images.githubusercontent.com/35610748/36166237-2414d690-10f2-11e8-86c7-9aa64c46700f.png)

After:
![after-hiding](https://user-images.githubusercontent.com/35610748/36166238-24538476-10f2-11e8-9103-e1bf82ed5f19.png)