### PR TITLE
Removes gap between table and header on small screens

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -172,6 +172,18 @@ thead th {
   z-index: 10;
 }
 
+@screen sm {
+  thead th {
+    top: 50px;
+  }
+}
+
+@screen md {
+  thead th {
+    top: 80px;
+  }
+}
+
 /** Table Arrows*/
 
 .table-component__th--sort-asc,


### PR DESCRIPTION
Fixes #111 

Not sure whether my current solution is the best approach. Would it be better (or more in line with tailwind) to add a class to the table heading on 'sm' screens instead of my current solution?