### PR TITLE
Fix all unit tests

### DIFF
--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -19,7 +19,7 @@ const methods = {
     )
   },
 
-  readableTimestamp(value) {
+  readableTimestamp(value, timeZoneOffset) {
     return moment()
       .utc()
       .set({
@@ -30,24 +30,28 @@ const methods = {
         minute: 0,
         second: 0,
       })
-      .add(Math.abs(new Date().getTimezoneOffset()), 'minutes')
+      .add(Math.abs(typeof timeZoneOffset !== 'undefined' ? timeZoneOffset : new Date().getTimezoneOffset()), 'minutes')
       .add(value, 'seconds')
       .format('DD.MM.YYYY HH:mm:ss')
   },
 
-  readableTimestampAgo(value) {
-    return moment()
-      .utc()
-      .set({
-        year: 2017,
-        month: 2,
-        date: 21,
-        hour: 13,
-        minute: 0,
-        second: 0,
-      })
-      .add(value, 'seconds')
-      .fromNow()
+  readableTimestampAgo(time, compareTime) {
+    const getTime = function (t) {
+      return moment()
+        .utc()
+        .set({
+          year: 2017,
+          month: 2,
+          date: 21,
+          hour: 13,
+          minute: 0,
+          second: 0,
+        })
+        .add(t, 'seconds');
+    }
+
+    const momentTime = getTime(time)
+    return typeof compareTime !== 'undefined' ? momentTime.from(getTime(compareTime)) : momentTime.fromNow();
   },
 
   truncate(value, length = 12) {

--- a/test/unit/specs/components/Footer.spec.js
+++ b/test/unit/specs/components/Footer.spec.js
@@ -1,6 +1,19 @@
-import { mount } from '@vue/test-utils'
+import { shallow, createLocalVue } from '@vue/test-utils'
 import sinon from 'sinon'
 import Footer from '@/components/Footer'
+import VueI18n from 'vue-i18n'
+
+const localVue = createLocalVue()
+localVue.use(VueI18n)
+const i18n = new VueI18n({
+  locale: "en",
+  fallbackLocale: 'en',
+  messages: { 'en': {}},
+  silentTranslationWarn: true
+})
+
+global.GIT_VERSION = "43496685190e3e768c3f5b1bc322ff8b7ed4c696"
+global.GIT_DATE = "2018-01-01"
 
 describe('Footer', () => {
   it('uses the current year always', () => {
@@ -11,8 +24,12 @@ describe('Footer', () => {
       useFakeTimers: new Date(year, 1)
     })
 
-    mount(Footer).vm.year.should.eql(year.toString())
+    const cmp = shallow(Footer, {
+      localVue,
+      i18n
+    })
 
+    expect(cmp.vm.year).toEqual(year.toString())
     sandbox.restore()
   })
 })

--- a/test/unit/specs/mixins/readable-timestamp-ago.spec.js
+++ b/test/unit/specs/mixins/readable-timestamp-ago.spec.js
@@ -2,6 +2,6 @@ import mixins from '@/mixins'
 
 describe('readable timestamp ago mixin', () => {
   it('should properly format the given data', () => {
-    expect(mixins.readableTimestampAgo(22231900)).toEqual('2 months ago')
+    expect(mixins.readableTimestampAgo(22231900, 26231900)).toEqual('2 months ago')
   })
 })

--- a/test/unit/specs/mixins/readable-timestamp.spec.js
+++ b/test/unit/specs/mixins/readable-timestamp.spec.js
@@ -2,6 +2,6 @@ import mixins from '@/mixins'
 
 describe('readable timestamp mixin', () => {
   it('should properly format the given data', () => {
-    expect(mixins.readableTimestamp(22231900)).toEqual('03.12.2017 22:31:40')
+    expect(mixins.readableTimestamp(22231900, 0)).toEqual('03.12.2017 20:31:40')
   })
 })


### PR DESCRIPTION
problems we had:

- readable-timestamp.spec.js compared time to locale date time (depending on where you live the test gave a different result)
- readable-timestamp-ago.spec.js always used "date time now", obviously this changes when time passes and the test was therefore never correct
- Footer.spec.js had problems because i18n and global variables were missing