### PR TITLE
Always show previous / next text on block button

### DIFF
--- a/src/components/block/Identity.vue
+++ b/src/components/block/Identity.vue
@@ -6,12 +6,12 @@
       <div class="text-xl text-white semibold">{{ block.id }}</div>
     </div>
     <div class="hidden sm:block">
-      <button @click="prevHandler" class="hover-button block-pager-button mr-5">
+      <button @click="prevHandler" class="block-pager-button mr-5">
         <img src="@/assets/images/icons/caret-left.svg" />
-        <span class="ml-2 hidden">{{ $t("Previous block") }}</span>
+        <span class="ml-2">{{ $t("Previous block") }}</span>
       </button>
-      <button @click="nextHandler" class="hover-button block-pager-button">
-        <span class="mr-2 hidden">{{ $t("Next block") }}</span>
+      <button @click="nextHandler" class="block-pager-button">
+        <span class="mr-2">{{ $t("Next block") }}</span>
         <img src="@/assets/images/icons/caret-right.svg" />
       </button>
     </div>


### PR DESCRIPTION
On the block page (e.g. http://localhost:8080/#/block/2349249940958423570) the buttons to go to next / previous only showed the arrow and showed text when hovering over it. Personally, I did not like the buttons jumping around when hovering, so I changed it to always show the next / previous text. 

Unsure whether this is wanted / the best solution. An alternative I thought of would be to make use of the existing tooltips and show the next / previous text when you hover over the button (as they are only shown on desktop anyway). That way we can keep the smaller and sleeker buttons, but don't have them jump around when trying to show more information. Let me know what you think! :)