### PR TITLE
Fix special transactions that were incorrectly colored as incoming

### DIFF
--- a/src/components/tables/Transactions.vue
+++ b/src/components/tables/Transactions.vue
@@ -33,7 +33,7 @@
 
       <table-column show="amount" :label="$t('Amount (token)', {token: networkToken()})" header-class="right-header-end-cell md:pr-4" cell-class="right-end-cell md:pr-4">
         <template slot-scope="row">
-          <transaction-amount :transaction="row"></transaction-amount>
+          <transaction-amount :transaction="row" :type="row.type"></transaction-amount>
         </template>
       </table-column>
 

--- a/src/components/tables/TransactionsDetail.vue
+++ b/src/components/tables/TransactionsDetail.vue
@@ -27,7 +27,7 @@
 
       <table-column show="amount" :label="$t('Amount (token)', {token: networkToken()})" header-class="right-header-cell" cell-class="right-cell">
         <template slot-scope="row">
-          <transaction-amount :transaction="row"></transaction-amount>
+          <transaction-amount :transaction="row" :type="row.type"></transaction-amount>
         </template>
       </table-column>
 

--- a/src/components/tables/mobile/Transactions.vue
+++ b/src/components/tables/mobile/Transactions.vue
@@ -30,7 +30,7 @@
         <div class="list-row-border-b">
           <div>{{ $t("Amount (token)", {token: networkToken()}) }}</div>
           <div>
-            <transaction-amount :transaction="transaction"></transaction-amount>
+            <transaction-amount :transaction="transaction" :type="transaction.type"></transaction-amount>
           </div>
         </div>
 

--- a/src/components/tables/mobile/TransactionsDetail.vue
+++ b/src/components/tables/mobile/TransactionsDetail.vue
@@ -25,7 +25,7 @@
         <div class="list-row-border-b">
           <div>{{ $t("Amount") }}</div>
           <div>
-            <transaction-amount :transaction="transaction"></transaction-amount>
+            <transaction-amount :transaction="transaction" :type="transaction.type"></transaction-amount>
           </div>
         </div>
 

--- a/src/components/utils/TransactionAmount.vue
+++ b/src/components/utils/TransactionAmount.vue
@@ -1,7 +1,7 @@
 <template>
   <span :class="{
     'text-red': transaction.senderId === $route.params.address,
-    'text-green': transaction.recipientId === $route.params.address,
+    'text-green': transaction.recipientId === $route.params.address && !isSpecialType,
   }">{{ readableCrypto(transaction.amount) }}</span>
 </template>
 
@@ -13,6 +13,19 @@ export default {
     transaction: {
       type: Object,
       required: true
+    },
+    type: {
+      type: Number,
+      required: true
+    }
+  },
+
+  computed: {
+    isSpecialType() {
+      if (this.type !== undefined) {
+        return this.type === 1 || this.type === 2 || this.type === 3
+      }
+      return false
     }
   }
 }


### PR DESCRIPTION
This adds an extra check on `transaction.type` when providing a color to a transaction. Originally, special transactions such as votes, signatures- and delegate registrations were given a green color, as the recipient corresponded to the current wallet. However, they are actually outgoing transactions (and are also shown on the 'sent' page) and should therefore be indicated in red.