### PR TITLE
 show previous / next buttons on small devices

### DIFF
--- a/src/components/block/Identity.vue
+++ b/src/components/block/Identity.vue
@@ -1,17 +1,21 @@
 <template>
-  <section class="mb-5 bg-theme-feature-background xl:rounded-lg flex items-center px-10 py-8">
-    <img class="mr-6" src="@/assets/images/icons/block.svg" />
-    <div class="flex-auto">
-      <div class="text-grey mb-2">{{ $t("Block ID") }}</div>
-      <div class="text-xl text-white semibold">{{ block.id }}</div>
+  <section class="mb-5 bg-theme-feature-background xl:rounded-lg flex flex-col sm:flex-row items-center px-10 py-8">
+    <div class="flex items-center flex-auto w-full sm:w-auto mb-5 sm:mb-0">
+      <img class="mr-6" src="@/assets/images/icons/block.svg" />
+      <div>
+        <div class="text-grey mb-2">{{ $t("Block ID") }}</div>
+        <div class="text-xl text-white semibold">{{ block.id }}</div>
+      </div>
     </div>
-    <div class="hidden sm:block">
+    <div class="flex w-full sm:block sm:w-auto justify-between">
       <button @click="prevHandler" class="hover-button block-pager-button mr-5">
         <img src="@/assets/images/icons/caret-left.svg" />
         <span class="ml-2 hidden">{{ $t("Previous block") }}</span>
+        <span class="ml-2 sm:hidden">{{ $t("Previous") }}</span>
       </button>
       <button @click="nextHandler" class="hover-button block-pager-button">
         <span class="mr-2 hidden">{{ $t("Next block") }}</span>
+        <span class="mr-2 sm:hidden">{{ $t("Next") }}</span>
         <img src="@/assets/images/icons/caret-right.svg" />
       </button>
     </div>
@@ -38,7 +42,7 @@ export default {
 </script>
 
 <style>
-.hover-button:hover span {
+.hover-button:hover span:first-of-type {
   display: inline-block;
 }
 </style>

--- a/src/components/block/Identity.vue
+++ b/src/components/block/Identity.vue
@@ -42,7 +42,9 @@ export default {
 </script>
 
 <style>
-.hover-button:hover span:first-of-type {
-  display: inline-block;
+@media (min-width: 576px) {
+  .hover-button:hover span:first-of-type {
+    display: inline-block;
+  }
 }
 </style>


### PR DESCRIPTION
added buttons for smaller devices with shorter text and underneath the block id (https://github.com/ArkEcosystem/ark-explorer/pull/145)

![image](https://user-images.githubusercontent.com/6547002/39747358-63fcd486-52ad-11e8-835d-0c3ce39921e6.png)
