### PR TITLE
content header whitespace wrapping

### DIFF
--- a/src/components/ContentHeader.vue
+++ b/src/components/ContentHeader.vue
@@ -5,7 +5,7 @@
       <div class="hidden sm:flex items-center text-theme-text-tertiary text-2xs px-3 sm:px-8 xl:px-6 py-3 mb-6 bg-stat-background rounded-md">
         <div class="pr-6">{{ $t("Height") }}: {{ height.toLocaleString() }}</div>
         <div class="pr-6">{{ $t("Network") }}: {{ $t(alias) }}</div>
-        <div class="pr-6">{{ $t("Supply") }}: {{ readableCrypto(supply) }}</div>
+        <div class="pr-6">{{ $t("Supply") }}: <span class="whitespace-no-wrap">{{ readableCrypto(supply) }}</span></div>
         <div>{{ $t("Market Cap") }}: <currency :amount="+supply"></currency></div>
       </div>
     </div>
@@ -20,7 +20,7 @@
       </div>
       <div>
         <span>{{ $t("Supply") }}:</span>
-        <span class="block md:inline-block">{{ readableCrypto(supply) }}</span>
+        <span class="block md:inline-block whitespace-no-wrap">{{ readableCrypto(supply) }}</span>
       </div>
     </div>
   </div>

--- a/src/components/utils/Currency.vue
+++ b/src/components/utils/Currency.vue
@@ -1,6 +1,6 @@
 <template>
-  <span>
-    {{ readableCurrency(amount) }} <span>{{ currencySymbol }}</span>
+  <span class="whitespace-no-wrap">
+    {{ readableCurrency(amount) }} {{ currencySymbol }}
   </span>
 </template>
 


### PR DESCRIPTION
this prevents the rather unpleasant line-breaks from being added in the price header (ContentHeader) between value and currency symbol on smaller devices, as shown below

![image](https://user-images.githubusercontent.com/6547002/39748122-93737484-52af-11e8-991e-2c2e7cca73a2.png)
