### PR TITLE
Always use two decimals for chart data

### DIFF
--- a/src/components/ChartWrapper.vue
+++ b/src/components/ChartWrapper.vue
@@ -105,7 +105,7 @@ export default {
             const name = store.getters['currency/name']
             const symbol = store.getters['currency/symbol']
 
-            return `${symbol} ${tooltipItem[0].yLabel} ${name}`
+            return `${symbol} ${Number(tooltipItem[0].yLabel).toFixed(2)} ${name}`
           },
           label: tooltipItem => ''
           // label: tooltipItem => `BTC ${tooltipItem.yLabel}`


### PR DESCRIPTION
The chart on the homepage did not always show the values with two decimal spaces (e.g. 3.3 instead of 3.30 and 3 instead of 3.00). Simple change to always show the currency with two decimal places