### PR TITLE
Keep amount from wrapping symbol

### DIFF
--- a/src/components/tables/Transactions.vue
+++ b/src/components/tables/Transactions.vue
@@ -33,7 +33,9 @@
 
       <table-column show="amount" :label="$t('Amount (token)', {token: networkToken()})" header-class="right-header-end-cell md:pr-4" cell-class="right-end-cell md:pr-4">
         <template slot-scope="row">
-          <transaction-amount :transaction="row" :type="row.type"></transaction-amount>
+          <span class="whitespace-no-wrap">
+            <transaction-amount :transaction="row" :type="row.type"></transaction-amount>
+          </span>
         </template>
       </table-column>
 

--- a/src/components/tables/TransactionsDetail.vue
+++ b/src/components/tables/TransactionsDetail.vue
@@ -27,7 +27,9 @@
 
       <table-column show="amount" :label="$t('Amount (token)', {token: networkToken()})" header-class="right-header-cell" cell-class="right-cell">
         <template slot-scope="row">
-          <transaction-amount :transaction="row" :type="row.type"></transaction-amount>
+          <span class="whitespace-no-wrap">
+            <transaction-amount :transaction="row" :type="row.type"></transaction-amount>
+          </span>
         </template>
       </table-column>
 


### PR DESCRIPTION
On smaller screens the ark symbol sometimes got pushed down in the tables

![before-no-wrap](https://user-images.githubusercontent.com/35610748/39777435-d7718f3c-5303-11e8-8fb5-6275b19d9b0f.png)

![after-no-wrap](https://user-images.githubusercontent.com/35610748/39777433-d74310c6-5303-11e8-95e7-37a9c2da22c3.png)