### PR TITLE
Made block page padding consistent with transactions

### DIFF
--- a/src/components/block/Details.vue
+++ b/src/components/block/Details.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="page-section py-8 mb-5">
-    <div class="px-10 py-4">
+    <div class="px-5 sm:px-10 py-4">
       <div class="list-row-border-b">
         <div>{{ $t("Transactions") }}</div>
         <div>{{ block.numberOfTransactions }}</div>


### PR DESCRIPTION
The padding on the "Blocks" page was very large (px-10) on small screens, this PR makes it consistent with how the "Transactions" page looks on smaller screens.