### PR TITLE
Fix next / previous block buttons no longer showing on small screens

### DIFF
--- a/src/components/block/Identity.vue
+++ b/src/components/block/Identity.vue
@@ -1,17 +1,21 @@
 <template>
-  <section class="mb-5 bg-theme-feature-background xl:rounded-lg flex items-center px-10 py-8">
-    <img class="mr-6" src="@/assets/images/icons/block.svg" />
-    <div class="flex-auto">
-      <div class="text-grey mb-2">{{ $t("Block ID") }}</div>
-      <div class="text-xl text-white semibold">{{ block.id }}</div>
+  <section class="mb-5 bg-theme-feature-background xl:rounded-lg flex flex-col md:flex-row items-center px-10 py-8">
+    <div class="flex items-center flex-auto w-full md:w-auto mb-5 md:mb-0">
+      <img class="mr-6" src="@/assets/images/icons/block.svg" />
+      <div>
+        <div class="text-grey mb-2">{{ $t("Block ID") }}</div>
+        <div class="text-xl text-white semibold">{{ block.id }}</div>
+      </div>
     </div>
-    <div class="hidden sm:block">
+    <div class="flex w-full md:block md:w-auto justify-between">
       <button @click="prevHandler" class="block-pager-button mr-5">
         <img src="@/assets/images/icons/caret-left.svg" />
-        <span class="ml-2">{{ $t("Previous block") }}</span>
+        <span class="ml-2 hidden md:block inline-button">{{ $t("Previous block") }}</span>
+        <span class="ml-2 md:hidden">{{ $t("Previous") }}</span>
       </button>
       <button @click="nextHandler" class="block-pager-button">
-        <span class="mr-2">{{ $t("Next block") }}</span>
+        <span class="mr-2 hidden md:block inline-button">{{ $t("Next block") }}</span>
+        <span class="mr-2 md:hidden">{{ $t("Next") }}</span>
         <img src="@/assets/images/icons/caret-right.svg" />
       </button>
     </div>
@@ -38,8 +42,8 @@ export default {
 </script>
 
 <style>
-@media (min-width: 576px) {
-  .hover-button:hover span:first-of-type {
+@media (min-width: 768px) {
+  .inline-button {
     display: inline-block;
   }
 }


### PR DESCRIPTION
Because of my other PR (#145) being merged after the one that added the buttons on small screens (#148), it got overwritten and they no longer appeared (sorry @dated). I've re-added them, with some slight adjustments, so they show up again.

Since the "previous block" text takes up quite some space, I've changed the media query to `768px` and the `sm` uses to `md`, otherwise it did not properly line up on screens that were between `sm` and `md` in size.