### PR TITLE
fixes menu button width if menu is open

### DIFF
--- a/src/components/header/menu/Desktop.vue
+++ b/src/components/header/menu/Desktop.vue
@@ -2,10 +2,10 @@
   <div class="absolute pin px-4 md:px-8 hidden sm:flex bg-theme-nav-background xl:rounded-r-md">
     <button
       @click="$store.dispatch('ui/setMenuVisible', false)"
-      class='px-4 py-3 md:py-6 flex-none flex items-center border-b-2 border-transparent hover:border-red text-theme-text-secondary'>
+      class='px-4 py-3 md:py-6 flex-none flex items-center border-b-2 margin-t-2 mr-3 border-transparent hover:border-red text-theme-text-secondary'>
       <!-- Inline this SVG so we can change color dynamically -->
       <svg
-        class="flex-none mr-3 fill-current"
+        class="flex-none fill-current"
         xmlns="http://www.w3.org/2000/svg"
         xmlns:xlink="http://www.w3.org/1999/xlink"
         width="15px" height="13px">


### PR DESCRIPTION
before:

![image](https://user-images.githubusercontent.com/6547002/39784145-b336f4c2-5317-11e8-89d9-121b4d919665.png)

after:

![image](https://user-images.githubusercontent.com/6547002/39784124-a3520a42-5317-11e8-84b9-6ff02818f45e.png)
