### PR TITLE
fixes clipped line in price chart

### DIFF
--- a/src/components/ChartWrapper.vue
+++ b/src/components/ChartWrapper.vue
@@ -159,6 +159,9 @@ export default {
             data: response.datasets
           }],
         }
+
+        let maxY = Math.max(...this.chartData.datasets[0].data);
+        this.options.scales.yAxes[0].ticks.max = maxY + 0.01;
       })
     },
 


### PR DESCRIPTION
in the current price chart the line is cut off at the top

![image](https://user-images.githubusercontent.com/6547002/39798661-b80bfc32-5361-11e8-9087-7a776c82cdd2.png)

by increasing the max value of the yAxis by a marginal amount the line gets shown correctly

![image](https://user-images.githubusercontent.com/6547002/39798695-dbf14634-5361-11e8-8f78-1ac622c73a2d.png)