### PR TITLE
changes 'max' option to 'suggestedMax' in ChartWrapper

### DIFF
--- a/src/components/ChartWrapper.vue
+++ b/src/components/ChartWrapper.vue
@@ -161,7 +161,7 @@ export default {
         }
 
         let maxY = Math.max(...this.chartData.datasets[0].data);
-        this.options.scales.yAxes[0].ticks.max = maxY + 0.01;
+        this.options.scales.yAxes[0].ticks.suggestedMax = maxY + 0.01;
       })
     },
 


### PR DESCRIPTION
this fixes the error introduced by https://github.com/ArkEcosystem/ark-explorer/pull/159