### PR TITLE
fixes currency menu not being visible for sm sized screens

### DIFF
--- a/src/components/header/currencies/Mobile.vue
+++ b/src/components/header/currencies/Mobile.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul class="menu-container w-full text-center max-w-480px justify-center bg-table-row list-reset absolute pin-b pin-l py-5 block sm:hidden">
+  <ul class="menu-container w-full text-center max-w-480px justify-center bg-table-row list-reset absolute pin-b pin-r py-5 block md:hidden">
     <li v-for="(symbol, currency) in currencies"
             @click="setCurrency(currency, symbol)"
             :key="currency"


### PR DESCRIPTION
pins the menu to the right side of the screen for better user experience

![image](https://user-images.githubusercontent.com/6547002/39815151-7081f002-5397-11e8-9d57-582fb1865b01.png)
