### PR TITLE
hides main menu when clicking other menu toggles

### DIFF
--- a/src/store/modules/ui.js
+++ b/src/store/modules/ui.js
@@ -45,6 +45,11 @@ export default {
     },
     setHeaderType: ({ commit }, value) => {
       commit({
+        type: types.SET_UI_MENU_VISIBLE,
+        value: null,
+      })
+
+      commit({
         type: types.SET_UI_HEADER_TYPE,
         value,
       })


### PR DESCRIPTION
with the main menu open on mobile, it had to be closed first in order to be able to bring up the currencies menu