### PR TITLE
fixes background color of links in mobile menus on hover

### DIFF
--- a/src/components/header/currencies/Mobile.vue
+++ b/src/components/header/currencies/Mobile.vue
@@ -3,7 +3,7 @@
     <li v-for="(symbol, currency) in currencies"
             @click="setCurrency(currency, symbol)"
             :key="currency"
-            class="inline-flex hover:bg-grey-light">
+            :class="[nightMode ? 'hover:bg-grey-dark' : 'hover:bg-grey-light', 'inline-flex justify-center']">
       <a href="#" class="cursor-pointer py-3 w-32 flex-none">{{ currency }}</a>
     </li>
   </ul>
@@ -15,6 +15,7 @@ import { mapGetters } from 'vuex'
 
 export default {
   computed: {
+    ...mapGetters('ui', ['nightMode']),
     ...mapGetters('currency', { currencyName: 'name' }),
     ...mapGetters('network', ['currencies'])
   },

--- a/src/components/header/menu/Mobile.vue
+++ b/src/components/header/menu/Mobile.vue
@@ -1,18 +1,18 @@
 <template>
   <ul class="menu-container w-full max-w-480px bg-table-row list-reset absolute pin-b pin-l py-5 block md:hidden">
-    <li class="flex justify-center hover:bg-grey-light">
+    <li :class="[nightMode ? 'hover:bg-grey-dark' : 'hover:bg-grey-light', 'flex justify-center']">
       <router-link :to="{ name: 'home' }" tag="div" class="cursor-pointer py-5 w-64 flex-none border-b border-theme-nav-border">{{ $t("Home") }}</router-link>
     </li>
-    <li class="flex justify-center hover:bg-grey-light">
+    <li :class="[nightMode ? 'hover:bg-grey-dark' : 'hover:bg-grey-light', 'flex justify-center']">
       <router-link :to="{ name: 'top-wallets', params: { page: 1 } }" tag="div" class="cursor-pointer py-5 w-64 flex-none border-b border-theme-nav-border">{{ $t("Top Wallets") }}</router-link>
     </li>
-    <li class="flex justify-center hover:bg-grey-light">
+    <li :class="[nightMode ? 'hover:bg-grey-dark' : 'hover:bg-grey-light', 'flex justify-center']">
       <router-link :to="{ name: 'delegate-monitor' }" tag="div" class="cursor-pointer py-5 w-64 flex-none">{{ $t("Delegate Monitor") }}</router-link>
     </li>
-    <!-- <li class="flex justify-center hover:bg-grey-light">
+    <!-- <li :class="[nightMode ? 'hover:bg-grey-dark' : 'hover:bg-grey-light', 'flex justify-center']">
       <router-link :to="{ name: 'statistics' }" tag="div" class="cursor-pointer py-5 w-64 flex-none border-b border-theme-nav-border">Statistics</router-link>
     </li> -->
-    <!-- <li class="flex justify-center hover:bg-grey-light">
+    <!-- <li :class="[nightMode ? 'hover:bg-grey-dark' : 'hover:bg-grey-light', 'flex justify-center']">
       <div class="py-5 w-64 flex-none">
         <span class="mr-2">Snapshots</span>
         <img src="@/assets/images/icons/download.svg" />
@@ -20,6 +20,16 @@
     </li> -->
   </ul>
 </template>
+
+<script type="text/ecmascript-6">
+import { mapGetters } from 'vuex'
+
+export default {
+  computed: {
+    ...mapGetters('ui', ['nightMode'])
+  }
+}
+</script>
 
 <style>
 .menu-container {


### PR DESCRIPTION
the links in the mobile menus were always assigned the `hover:bg-grey-light` class, resulting in the following when using the night theme.

![image](https://user-images.githubusercontent.com/6547002/39870945-735ba7ba-5463-11e8-9ace-14214d3ea87c.png)

through this pr the class gets assigned dynamically based on theme.