### PR TITLE
Fix issue where copy icon could get overlapped

### DIFF
--- a/src/components/wallet/Details.vue
+++ b/src/components/wallet/Details.vue
@@ -12,8 +12,10 @@
         v-if="view === 'public'"
         class="pr-8 flex-auto min-w-0">
         <div class="text-grey mb-2">{{ $t("Address") }}</div>
-        <div class="text-lg text-white semibold truncate">
-          <span class="mr-2">{{ wallet.address }}</span>
+        <div class="flex">
+          <div class="text-lg text-white semibold truncate">
+            <span class="mr-2">{{ wallet.address }}</span>
+          </div>
           <clipboard v-if="wallet.address" :value="wallet.address"></clipboard>
         </div>
       </div>
@@ -22,8 +24,10 @@
         v-if="view === 'private' && wallet.publicKey"
         class="pr-8 flex-auto min-w-0">
         <div class="text-grey mb-2">{{ $t("Public Key") }}</div>
-        <div class="text-lg text-white semibold truncate mr-2">
-          <span class="mr-2">{{ wallet.publicKey }}</span>
+        <div class="flex">
+          <div class="text-lg text-white semibold truncate mr-2">
+            <span class="mr-2">{{ wallet.publicKey }}</span>
+          </div>
           <clipboard v-if="wallet.publicKey" :value="wallet.publicKey"></clipboard>
         </div>
       </div>


### PR DESCRIPTION
On smaller screens, the copy icon could get overlapped by the content next to it. This PR makes sure that the copy icon stays visible.

Before:
![copy-before](https://user-images.githubusercontent.com/35610748/39893920-974c60fa-54a5-11e8-923a-7e9dd0841295.png)

Now:
![copy-after](https://user-images.githubusercontent.com/35610748/39893919-971dbf0c-54a5-11e8-9d44-cd2d37449f93.png)