### PR TITLE
Show copy tooltip when clicking icon on small screens

### DIFF
--- a/src/components/utils/Clipboard.vue
+++ b/src/components/utils/Clipboard.vue
@@ -1,5 +1,5 @@
 <template>
-  <button class="flex-none" @click="copy" v-tooltip="copying ? $t('Copied!') : $t('Copy to Clipboard')">
+  <button class="flex-none" @click="copy" v-tooltip="{ show: isMobileCopying, content: copying ? $t('Copied!') : $t('Copy to Clipboard'), trigger:'hover'}">
     <img :class="{
       'block': !copying, 'block animated wobble': copying
     }" src="@/assets/images/icons/copy.svg" ref="copyImage" />
@@ -15,7 +15,10 @@ export default {
     },
   },
 
-  data: () => ({ copying: false }),
+  data: () => ({ 
+    copying: false,
+    isMobileCopying: false
+  }),
 
   methods: {
     copy() {
@@ -31,6 +34,11 @@ export default {
         this.copying = true
 
         setTimeout(() => (this.copying = false), 500)
+
+        if (window.innerWidth < 768) {
+          this.isMobileCopying = true
+          setTimeout(() => (this.isMobileCopying = false), 400) // If set to 500, it will briefly show 'Copy to clipboard' before closing tooltip
+        }
 
         document.execCommand('copy')
       } catch (err) {


### PR DESCRIPTION
On mobile devices, the tooltip for the copy icon did not properly trigger. As a result, you would only see the icon wobble a bit, which I found unclear (sometimes the shaking indicate that an action failed, while in this case it succeeded). I've added another property for small devices, which set the tooltip to visible while it is copying. That way the tooltip shortly shows on mobile devices too, and automatically hides after copying has finished.

To ensure that you don't briefly see `Copy to Clipboard` after the `Copied` message, the timeout for the visibility is slightly lower on small screens. 