### PR TITLE
adds vertical alignement to the transaction page header

### DIFF
--- a/src/pages/Transaction.vue
+++ b/src/pages/Transaction.vue
@@ -3,17 +3,21 @@
     <content-header>{{ $t("Transaction") }}</content-header>
 
     <section class="mb-5">
-      <div class="px-5 sm:px-10 py-8 bg-theme-feature-background flex xl:rounded-lg items-end">
+      <div class="px-5 sm:px-10 py-8 bg-theme-feature-background flex xl:rounded-lg items-center">
         <div class="mr-6 flex-none">
           <img class="block" src="@/assets/images/icons/transaction.svg" />
         </div>
         <div  class="flex-auto min-w-0">
           <div class="text-grey mb-2">{{ $t("Transaction ID") }}</div>
-          <div class="text-xl text-white semibold truncate">{{ transaction.id }}</div>
+          <div class="flex">
+            <div class="text-xl text-white semibold truncate">
+              <span class="mr-2">{{ transaction.id }}</span>
+            </div>
+            <clipboard
+              v-if="transaction.id"
+              :value="transaction.id"></clipboard>
+          </div>
         </div>
-        <clipboard
-          v-if="transaction.id"
-          :value="transaction.id"></clipboard>
       </div>
     </section>
 


### PR DESCRIPTION
the current alignement of the header is slightly off and does not reflect the design of other pages

Transaction Details:
![image](https://user-images.githubusercontent.com/6547002/39915213-97d4e238-5507-11e8-8696-17b47b7df674.png)

Wallet Details:
![image](https://user-images.githubusercontent.com/6547002/39915270-c4f366a4-5507-11e8-8841-43da2f2bf0c2.png)

this pr vertically centers the logo on the left and places the 'copy to clipboard' button directly after the transaction id to keep the use of that button constistent.
![image](https://user-images.githubusercontent.com/6547002/39915443-43d2954e-5508-11e8-8c38-96b3f4739263.png)
