### PR TITLE
Use container to show currencies on screens below xl size

### DIFF
--- a/src/components/header/Default.vue
+++ b/src/components/header/Default.vue
@@ -63,7 +63,6 @@ export default {
 
   computed: {
     ...mapGetters('network', { networkDefaults: 'defaults' }),
-
     ...mapGetters('ui', ['menuVisible', 'priceChart']),
 
     shouldDisplayCurrency() {

--- a/src/components/header/Main.vue
+++ b/src/components/header/Main.vue
@@ -7,7 +7,7 @@
       <img class="logo max-w-25px md:max-w-38px" src="@/assets/images/ark-logo.png" />
     </router-link>
 
-    <div class="w-full relative hidden md:flex">
+    <div class="w-full relative hidden xl:flex">
       <header-search v-if="headerType === 'search'"></header-search>
 
       <header-desktop-currencies v-else-if="headerType === 'currencies'"></header-desktop-currencies>
@@ -16,7 +16,7 @@
 
       <header-desktop-menu v-if="menuVisible"></header-desktop-menu>
     </div>
-    <div class="w-full relative flex md:hidden">
+    <div class="w-full relative flex xl:hidden">
       <header-search v-if="headerType === 'search'"></header-search>
 
       <header-default v-else></header-default>

--- a/src/components/header/currencies/Desktop.vue
+++ b/src/components/header/currencies/Desktop.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full px-10 hidden md:flex">
+  <div class="w-full px-10 hidden xl:flex">
     <button @click="$store.dispatch('ui/setHeaderType', null)" class="mr-4">
       <img src="@/assets/images/icons/cross.svg" />
     </button>

--- a/src/components/header/currencies/Desktop.vue
+++ b/src/components/header/currencies/Desktop.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full px-10 hidden md:flex items-center">
+  <div class="w-full px-10 hidden xl:flex items-center">
     <button @click="$store.dispatch('ui/setHeaderType', null)" class="close-button">
       <img src="@/assets/images/icons/cross.svg" />
     </button>

--- a/src/components/header/currencies/Mobile.vue
+++ b/src/components/header/currencies/Mobile.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul class="menu-container w-full text-center max-w-480px justify-center bg-table-row list-reset absolute pin-b pin-r py-5 block md:hidden">
+  <ul class="menu-container w-full text-center max-w-480px justify-center bg-table-row list-reset absolute pin-b pin-r py-5 block xl:hidden">
     <li v-for="(symbol, currency) in currencies"
             @click="setCurrency(currency, symbol)"
             :key="currency"
@@ -39,14 +39,6 @@ export default {
 </script>
 
 <style>
-  .search-input::placeholder {
-    color: var(--color-theme-text-placeholder);
-  }
-
-  .search-icon:hover {
-    box-shadow: 0 0 13px 2px rgba(197, 197, 213, 0.24);
-  }
-
   .menu-container {
     transform: translateY(100%);
   }

--- a/src/components/header/menu/Desktop.vue
+++ b/src/components/header/menu/Desktop.vue
@@ -26,11 +26,3 @@
     </a> -->
   </div>
 </template>
-
-<style>
-.menu-container {
-  transform: translateY(100%);
-  max-width: 480px;
-  width: 100%;
-}
-</style>


### PR DESCRIPTION
Due to the amount of currencies in the explorer, the list would be too long to display on desktop screens that did not correspond to `xl` in size (see below image). Therefore this PR changes the header logic to show the container on `md` screens too.

![currency-overflow](https://user-images.githubusercontent.com/35610748/39958656-43c631ba-5606-11e8-9bdd-201894075dd9.png)

Additionally I've removed some unused styles that I came across in the header files

