### PR TITLE
Made truncate function properly use length param

### DIFF
--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -55,8 +55,9 @@ const methods = {
   },
 
   truncate(value, length = 12) {
+    const truncationLength = Math.floor((length - 1) / 2);
     return (value.length > length)
-      ? `${value.slice(0, 5)}...${value.slice(value.length - 5)}`
+      ? `${value.slice(0, truncationLength)}...${value.slice(value.length - truncationLength)}`
       : value
   },
 


### PR DESCRIPTION
The truncate function takes a `length` parameter, but it was never used in the function. For smartbridge messages this would mean that 35 characters was allowed, but when a message consisted of 36 characters, it would be truncated to 13 characters total.