### PR TITLE
Fix wrong transactions being shown for a wallet

### DIFF
--- a/src/components/wallet/Transactions.vue
+++ b/src/components/wallet/Transactions.vue
@@ -28,10 +28,10 @@
           {{ $t("Received") }}
         </div>
       </nav>
-      <div class="hidden sm:block" v-if="transactions.length > 0">
+      <div class="hidden sm:block">
         <table-transactions-detail :transactions="transactions"></table-transactions-detail>
       </div>
-      <div class="sm:hidden" v-if="transactions.length > 0">
+      <div class="sm:hidden">
         <table-transactions-detail-mobile :transactions="transactions"></table-transactions-detail-mobile>
       </div>
       <div class="mx-10 mt-10 flex flex-wrap" v-if="transactions.length >= 25">
@@ -71,10 +71,12 @@ export default {
 
   methods: {
     getTransactions() {
-      TransactionService[`${this.type}ByAddress`](
-        this.wallet.address,
-        this.page
-      ).then(transactions => (this.transactions = transactions))
+      if (this.wallet.address !== undefined) {
+        TransactionService[`${this.type}ByAddress`](
+          this.wallet.address,
+          this.page
+        ).then(transactions => (this.transactions = transactions))
+      }
     },
   },
 }

--- a/src/components/wallet/Transactions.vue
+++ b/src/components/wallet/Transactions.vue
@@ -28,10 +28,10 @@
           {{ $t("Received") }}
         </div>
       </nav>
-      <div class="hidden sm:block">
+      <div class="hidden sm:block" v-if="transactions.length > 0">
         <table-transactions-detail :transactions="transactions"></table-transactions-detail>
       </div>
-      <div class="sm:hidden">
+      <div class="sm:hidden" v-if="transactions.length > 0">
         <table-transactions-detail-mobile :transactions="transactions"></table-transactions-detail-mobile>
       </div>
       <div class="mx-10 mt-10 flex flex-wrap" v-if="transactions.length >= 25">


### PR DESCRIPTION
Sometimes when navigating to a wallet, it would briefly show the transactions of the wallet and then replace them with the latest transactions (as on the home page). This PR adds a check for an `undefined` wallet param, so it will no longer show those wrong transactions.

Steps to reproduce the issue:

1. go to the [explorer](https://explorer.ark.io)
2. click on an entry in the transactions table
3. wallet should load up with the right transactions
4. from this wallet, click on another recipient so you navigate to another wallet
5. this wallet should briefly show the right transactions, after which they get replaced with the latest transactions from the home page (if not: repeat step 4 :P)