### PR TITLE
adds hover style to block-pager-button

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -324,7 +324,8 @@ thead th {
   @apply .bg-theme-button .text-theme-button-text .semibold .py-5 .px-8 .border-transparent .rounded
 }
 
-.pager-button:hover {
+.pager-button:hover,
+.block-pager-button:hover {
   @apply .bg-blue .text-white
 }
 


### PR DESCRIPTION
there is currently no hover styling applied to the `block-pager-button`s. this pr adds the same style as is used for the `pager-button` class.

![image](https://user-images.githubusercontent.com/6547002/39969525-2931ebbe-56dd-11e8-9445-8b738d32526e.png)
