### PR TITLE
slight improvements to block page ux

### DIFF
--- a/src/components/block/Identity.vue
+++ b/src/components/block/Identity.vue
@@ -4,7 +4,7 @@
       <img class="mr-6" src="@/assets/images/icons/block.svg" />
       <div>
         <div class="text-grey mb-2">{{ $t("Block ID") }}</div>
-        <div class="text-xl text-white semibold">{{ block.id }}</div>
+        <div class="text-xl text-white semibold">{{ block.id ? block.id : "&nbsp;" }}</div>
       </div>
     </div>
     <div class="flex w-full md:block md:w-auto justify-between">

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -107,11 +107,13 @@ const methods = {
   },
 
   readableCrypto(value, appendCurrency = true) {
-    value = (value /= Math.pow(10, 8)).toLocaleString(undefined, {
-      maximumFractionDigits: 8,
-    })
+    if (typeof value != 'undefined') {
+      value = (value /= Math.pow(10, 8)).toLocaleString(undefined, {
+        maximumFractionDigits: 8,
+      })
 
-    return appendCurrency ? `${value} ${store.getters['network/symbol']}` : value
+      return appendCurrency ? `${value} ${store.getters['network/symbol']}` : value
+    }
   },
 
   networkToken() {


### PR DESCRIPTION
while fetching the next block, the div containing the block id would get removed from the dom, resulting in a slight change in the height of the parent container. while fetching the next block, the fields containing a currency value would briefly display 'NaN Ѧ'