### PR TITLE
Limit to 2 decimals for wallet balance in wallet lists

### DIFF
--- a/src/components/tables/Wallets.vue
+++ b/src/components/tables/Wallets.vue
@@ -15,7 +15,7 @@
 
       <table-column show="balance" :label="$t('Balance')" header-class="right-header-cell" cell-class="right-cell">
         <template slot-scope="row">
-          {{ readableCrypto(row.balance) }}
+          {{ readableCrypto(row.balance,true,2) }}
         </template>
       </table-column>
 

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -106,10 +106,10 @@ const methods = {
       })
   },
 
-  readableCrypto(value, appendCurrency = true) {
+  readableCrypto(value, appendCurrency = true, decimals = 8) {
     if (typeof value != 'undefined') {
       value = (value /= Math.pow(10, 8)).toLocaleString(undefined, {
-        maximumFractionDigits: 8,
+        maximumFractionDigits: decimals,
       })
 
       return appendCurrency ? `${value} ${store.getters['network/symbol']}` : value


### PR DESCRIPTION
Suggestion to improve balance readability in wallet lists.

Added a parameter in readableCrypto function so that we can control the decimals we want.