### PR TITLE
Mixins truncate function improvement + tests

### DIFF
--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -55,9 +55,10 @@ const methods = {
   },
 
   truncate(value, length = 12) {
+    const odd = length % 2;
     const truncationLength = Math.floor((length - 1) / 2);
     return (value.length > length)
-      ? `${value.slice(0, truncationLength)}...${value.slice(value.length - truncationLength)}`
+      ? `${value.slice(0, truncationLength - odd)}...${value.slice(value.length - truncationLength + 1)}`
       : value
   },
 

--- a/test/unit/specs/mixins/truncate.spec.js
+++ b/test/unit/specs/mixins/truncate.spec.js
@@ -2,6 +2,9 @@ import mixins from '@/mixins'
 
 describe('truncate mixin', () => {
   it('should properly format the given data', () => {
-    expect(mixins.truncate('Hello World', 8)).toEqual('Hello...World')
+    expect(mixins.truncate('Hello World', 8)).toEqual('Hel...ld')
+    expect(mixins.truncate('ThisIsA24CharacterString', 24)).toEqual('ThisIsA24CharacterString')
+    expect(mixins.truncate('ThisIsA24CharacterString', 23)).toEqual('ThisIsA24C...cterString')
+    expect(mixins.truncate('&ThisIsA25CharacterString', 24)).toEqual('&ThisIsA25C...cterString')
   })
 })


### PR DESCRIPTION
Issue : When we asked the truncate function to truncate 'ThisIsA24CharacterString' to 23 characters, it would output 'ThisIsA24Ch...acterString' which is a 25 characters string.
Doesn't look good to me : in this case we truncate a 24 characters string into... a longer string 😄 

So here is a fix so that when we ask a string to be truncated to less characters, the output string has exactly the character length asked.
(we just need to take into account that we are adding three characters '...' and truncate accordingly)

Also, updated and added tests on this truncate function.