### PR TITLE
Tests Footer : Rename shallow to shallowMount

### DIFF
--- a/test/unit/specs/components/Footer.spec.js
+++ b/test/unit/specs/components/Footer.spec.js
@@ -1,4 +1,4 @@
-import { shallow, createLocalVue } from '@vue/test-utils'
+import { shallowMount, createLocalVue } from '@vue/test-utils'
 import sinon from 'sinon'
 import Footer from '@/components/Footer'
 import VueI18n from 'vue-i18n'
@@ -24,7 +24,7 @@ describe('Footer', () => {
       useFakeTimers: new Date(year, 1)
     })
 
-    const cmp = shallow(Footer, {
+    const cmp = shallowMount(Footer, {
       localVue,
       i18n
     })


### PR DESCRIPTION
When running `yarn test` I got this error : 

`console.error node_modules/@vue/test-utils/dist/vue-test-utils.js:15
      [vue-test-utils]: shallow has been renamed to shallowMount. shallow will be removed in 1.0.0, use shallowMount instead`

So here is the rename 👍 