### PR TITLE
Rename "Vendor field" to "Smartbridge" in Transaction detail

### DIFF
--- a/src/pages/Transaction.vue
+++ b/src/pages/Transaction.vue
@@ -58,7 +58,7 @@
         </div>
 
         <div class="list-row-border-b" v-if="transaction.vendorField">
-          <div>{{ $t("Vendor field") }}</div>
+          <div>{{ $t("Smartbridge") }}</div>
           <div>{{ transaction.vendorField }}</div>
         </div>
 


### PR DESCRIPTION
This field is called "Smartbridge" in transactions list but it's "Vendor field" in transaction detail.

I think "Smartbridge" is the correct label ?