### PR TITLE
Fix smartbridge text being pushed down

### DIFF
--- a/src/pages/Transaction.vue
+++ b/src/pages/Transaction.vue
@@ -57,9 +57,9 @@
           <div>{{ readableTimestamp(transaction.timestamp) }}</div>
         </div>
 
-        <div class="list-row-border-b" v-if="transaction.vendorField">
-          <div>{{ $t("Smartbridge") }}</div>
-          <div>{{ transaction.vendorField }}</div>
+        <div class="list-row-border-b-no-wrap" v-if="transaction.vendorField">
+          <div class="mr-4">{{ $t("Smartbridge") }}</div>
+          <div class="text-right">{{ transaction.vendorField }}</div>
         </div>
 
         <div class="list-row" v-if="transaction.blockid">

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -277,6 +277,10 @@ thead th {
   @apply .list-row .border-b
 }
 
+.list-row-border-b-no-wrap {
+  @apply .list-row-border-b .flex-no-wrap;
+}
+
 .row-mobile {
   @apply .px-5 .py-4
 }


### PR DESCRIPTION
On smaller screens / mobile devices, long smartbridge texts would get pushed down like this:

![wrap](https://user-images.githubusercontent.com/35610748/40588332-3bb706b6-61dc-11e8-9354-9e91e496fb6f.png)

This PR removes the `flex-wrap` property from the smartbridge row, so we end up with this instead:

![no-wrap](https://user-images.githubusercontent.com/35610748/40588338-531aac7c-61dc-11e8-89bc-150a2a4b85fd.png)

Additionally, I've added a margin to the smartbridge label field, so we don't end up with this anymore:

![no-margin](https://user-images.githubusercontent.com/35610748/40588345-69bc53f4-61dc-11e8-8564-8cf7e1de979c.png)
