### PR TITLE
displays pubkey with default truncated length

### DIFF
--- a/src/components/wallet/Details.vue
+++ b/src/components/wallet/Details.vue
@@ -97,7 +97,7 @@
           <div class="md:w-1/2 px-6 w-full" v-if="wallet.publicKey">
             <div class="text-grey mb-2">{{ $t("Public Key") }}</div>
             <div class="text-white flex">
-              <span class="mr-2">{{ truncate(wallet.publicKey, 36) }}</span>
+              <span class="mr-2">{{ truncate(wallet.publicKey) }}</span>
               <clipboard v-if="wallet.publicKey" :value="wallet.publicKey"></clipboard>
             </div>
           </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6547002/40588982-24706a2e-61e6-11e8-99ca-6277e411b78a.png)

the public key is clearly too long for small devices. this pr sets the truncated key to the default length.

![image](https://user-images.githubusercontent.com/6547002/40588992-55d08798-61e6-11e8-8591-03e7b077b635.png)
