### PR TITLE
sets default truncation length to 13

### DIFF
--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -54,7 +54,7 @@ const methods = {
     return typeof compareTime !== 'undefined' ? momentTime.from(getTime(compareTime)) : momentTime.fromNow();
   },
 
-  truncate(value, length = 12) {
+  truncate(value, length = 13) {
     const odd = length % 2;
     const truncationLength = Math.floor((length - 1) / 2);
     return (value.length > length)


### PR DESCRIPTION
the default truncation length was set to 12. this results in a asymmetric string like `AUYoW...SKCq`. five letters on the left, four on right. by setting the length to 13 we get a nice symmetric string with five letters on each side, e.g. `AUYoW...9SKCq`.