### PR TITLE
truncates smartbridge text from the right

### DIFF
--- a/src/components/tables/mobile/Transactions.vue
+++ b/src/components/tables/mobile/Transactions.vue
@@ -22,9 +22,9 @@
           <link-wallet :address="transaction.recipientId" :type="transaction.type"></link-wallet>
         </div>
 
-        <div class="list-row-border-b" v-if="truncate(transaction.vendorField || '')">
-          <div>{{ $t("Smartbridge") }}</div>
-          <div>{{ truncate(transaction.vendorField || '') }}</div>
+        <div class="list-row-border-b-no-wrap" v-if="truncate(transaction.vendorField || '')">
+          <div class="mr-4">{{ $t("Smartbridge") }}</div>
+          <div class="truncate">{{ transaction.vendorField }}</div>
         </div>
 
         <div class="list-row-border-b">


### PR DESCRIPTION
on small devices the smartbridge text is currently being truncated in the middle.
![image](https://user-images.githubusercontent.com/6547002/40589274-b5d174be-61ea-11e8-82a1-48ad065b7bcc.png)
with text, as opposed to the address/public key, this does not make much sense. this pr changes the div to display the smartbridge truncated from the right.
![image](https://user-images.githubusercontent.com/6547002/40589281-d23752d6-61ea-11e8-8581-f68d7c76c2b4.png)
