### PR TITLE
Don't truncate top wallet / voter wallet addresses

### DIFF
--- a/src/components/links/Wallet.vue
+++ b/src/components/links/Wallet.vue
@@ -5,7 +5,7 @@
         <span v-if="isKnown">{{ knownWallets[address] }}</span>
         <span v-else-if="delegate">{{ delegate.username }}</span>
         <span v-else-if="hasDefaultSlot"><slot></slot></span>
-        <span v-else-if="address">{{ truncate(address) }}</span>
+        <span v-else-if="address">{{ trunc ? truncate(address) : address }}</span>
       </router-link>
 
       <span v-if="type === 1">{{ $t("2nd Signature Registration") }}</span>
@@ -41,6 +41,10 @@ export default {
     type: {
       type: Number,
     },
+    trunc: {
+      type: Boolean,
+      default: true
+    }
   },
 
   data: () => ({ delegate: null }),

--- a/src/components/tables/Wallets.vue
+++ b/src/components/tables/Wallets.vue
@@ -9,7 +9,7 @@
 
       <table-column show="address" :label="$t('Address')" header-class="left-header-cell" cell-class="left-cell">
         <template slot-scope="row">
-          <link-wallet :address="row.address"></link-wallet>
+          <link-wallet :address="row.address" :trunc="false"></link-wallet>
         </template>
       </table-column>
 


### PR DESCRIPTION
Removes truncation of wallet addresses on large screens for the `top wallets` and `voters` page, since there was a lot of empty space in those tables.

Before:
![schermafbeelding 2018-05-27 om 21 33 03](https://user-images.githubusercontent.com/35610748/40589879-b40d10e2-61f5-11e8-93ac-dd97bbe4a958.png)

After:
![schermafbeelding 2018-05-27 om 21 32 46](https://user-images.githubusercontent.com/35610748/40589878-b2b8c4b6-61f5-11e8-8cd0-2d969fa089d3.png)