### PR TITLE
Update test-utils dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "vuex-router-sync": "^5.0.0"
   },
   "devDependencies": {
-    "@vue/test-utils": "^1.0.0-beta.11",
+    "@vue/test-utils": "^1.0.0-beta.16",
     "autoprefixer": "^7.2.5",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.2.1",


### PR DESCRIPTION
The `shallowMount` function was introduced by PR #189. But this function is only available since the latest beta release of vue-test-utils; on older versions it will throw an error as it doesn't exist yet. Therefore this PR to update that dependency accordingly.