### PR TITLE
removes 'See all' links from wallet details

### DIFF
--- a/src/components/wallet/Delegate.vue
+++ b/src/components/wallet/Delegate.vue
@@ -25,12 +25,13 @@
       <div>{{ readableCrypto(delegate.forged) }}</div>
     </div>
 
-    <div class="list-row-border-b">
+    <div class="list-row-border-b" v-show="delegate.producedblocks > 0">
       <div>{{ $t("Blocks") }}</div>
       <div>
-        <span>{{ delegate.producedblocks }}</span>
-        <span class="text-grey">({{ delegate.missedblocks }} {{ $t("missed") }})</span>
-        <router-link v-if="delegate.producedblocks > 0" :to="{ name: 'wallet-blocks', params: { address: delegate.address, page: 1 } }">{{ $t("See all") }}</router-link>
+        <router-link :to="{ name: 'wallet-blocks', params: { address: delegate.address, page: 1 } }">
+          <span>{{ delegate.producedblocks }}</span>
+          <span v-if="delegate.missedblocks">({{ delegate.missedblocks }} {{ $t("missed") }})</span>
+        </router-link>
       </div>
     </div>
   </div>

--- a/src/components/wallet/Voters.vue
+++ b/src/components/wallet/Voters.vue
@@ -2,8 +2,9 @@
   <div class="border-t list-row" v-show="Object.keys(voters).length">
     <div>{{ $t("Voters") }}</div>
     <div>
-      <span class="mr-2">{{ voters.length }}</span>
-      <router-link v-if="wallet.address" :to="{ name: 'wallet-voters', params: { address: wallet.address, username: username, page: 1 } }">{{ $t("See all") }}</router-link>
+      <router-link v-if="wallet.address" :to="{ name: 'wallet-voters', params: { address: wallet.address, username: username, page: 1 } }">
+        <span>{{ voters.length }}</span>
+      </router-link>
     </div>
   </div>
 </template>


### PR DESCRIPTION
the 'See all' brings some inconsistency to the design - the blue text color is indicative enough.

![image](https://user-images.githubusercontent.com/6547002/40603718-15a3bcf4-625d-11e8-840e-588379707ed7.png)

-->

![image](https://user-images.githubusercontent.com/6547002/40603701-04e80302-625d-11e8-9822-957e064c9cf2.png)
