### PR TITLE
adds margin to content header

### DIFF
--- a/src/components/ContentHeader.vue
+++ b/src/components/ContentHeader.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="flex justify-between flex-wrap px-5 sm:px-10 xl:px-0">
-      <h1 class="text-2xl md:text-3xl mb-6 text-theme-text-primary"><slot></slot></h1>
+      <h1 class="text-2xl md:text-3xl mb-6 text-theme-text-primary sm:mr-10"><slot></slot></h1>
       <div class="hidden sm:flex items-center text-theme-text-tertiary text-2xs px-3 sm:px-8 xl:px-6 py-3 mb-6 bg-stat-background rounded-md">
         <div class="pr-6">{{ $t("Height") }}: {{ height.toLocaleString() }}</div>
         <div class="pr-6">{{ $t("Network") }}: {{ $t(alias) }}</div>


### PR DESCRIPTION
to prevent this from happening:
![image](https://user-images.githubusercontent.com/6547002/40604332-fd595fbc-625e-11e8-9717-7323e1f87b05.png)
-->
![image](https://user-images.githubusercontent.com/6547002/40604360-15ee6f72-625f-11e8-9b54-265ada39c379.png)
