### PR TITLE
adds github bounty account to known wallets

### DIFF
--- a/networks/mainnet.json
+++ b/networks/mainnet.json
@@ -26,6 +26,7 @@
     "AFrPtEmzu6wdVpa2CnRDEKGQQMWgq8nE9V": "Binance",
     "AJbmGnDAx9y91MQCDApyaqZhn6fBvYX9iJ": "Cryptopia",
     "AYCTHSZionfGoQsRnv5gECEuFWcZXS38gs": "ARK Bounty",
+    "AZmQJ2P9xg5j6VPZWjcTzWDD4w7Qww2KGX": "ARK GH Bounty",
     "ALgvTAoz5Vi9easHqBK6aEMKatHb4beCXm": "ARK Shield",
     "AUDud8tvyVZa67p3QY7XPRUTjRGnWQQ9Xv": "ARK Team",
     "AUexKjGtgsSpVzPLs6jNMM6vJ6znEVTQWK": "Bittrex",

--- a/networks/mainnet.json
+++ b/networks/mainnet.json
@@ -26,7 +26,7 @@
     "AFrPtEmzu6wdVpa2CnRDEKGQQMWgq8nE9V": "Binance",
     "AJbmGnDAx9y91MQCDApyaqZhn6fBvYX9iJ": "Cryptopia",
     "AYCTHSZionfGoQsRnv5gECEuFWcZXS38gs": "ARK Bounty",
-    "AZmQJ2P9xg5j6VPZWjcTzWDD4w7Qww2KGX": "ARK GH Bounty",
+    "AZmQJ2P9xg5j6VPZWjcTzWDD4w7Qww2KGX": "ARK GitHub Bounty",
     "ALgvTAoz5Vi9easHqBK6aEMKatHb4beCXm": "ARK Shield",
     "AUDud8tvyVZa67p3QY7XPRUTjRGnWQQ9Xv": "ARK Team",
     "AUexKjGtgsSpVzPLs6jNMM6vJ6znEVTQWK": "Bittrex",


### PR DESCRIPTION
as can be seen [here](https://explorer.ark.io/transaction/252de8153b00804a8c7cba6a4484a12c52e55aa392e451d661d245461665cefb), a new bounty wallet has been created, especially for the github bounties. i am guessing all github bounties will be paid through that wallet from now on - @boldninja might be able to confirm?

i set the name to "ARK GH Bounty" to keep it short, i hope that's fine!