### PR TITLE
Display forged blocks instead of forged arks in delegate monitor list...

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -77,7 +77,6 @@ export default {
     this.updateSupply()
     this.updateHeight()
     this.updateDelegates()
-    this.updateForged()
   },
 
   mounted() {
@@ -117,18 +116,12 @@ export default {
       this.$store.dispatch('delegates/setDelegates', delegates)
     },
 
-    async updateForged() {
-      const response = await DelegateService.forged()
-      this.$store.dispatch('delegates/setForged', response)
-    },
-
     initialiseTimer() {
       this.timer = setInterval(() => {
         this.updateCurrencyRate()
         this.updateSupply()
         this.updateHeight()
         this.updateDelegates()
-        this.updateForged()
       }, 5 * 60 * 1000)
     },
   },

--- a/src/components/monitor/ActiveDelegates.vue
+++ b/src/components/monitor/ActiveDelegates.vue
@@ -16,9 +16,9 @@
       </template>
     </table-column>
 
-    <table-column show="producedblocks" :label="$t('Forged')" header-class="left-header-cell hidden xl:table-cell" cell-class="py-3 px-4 text-left border-none hidden xl:table-cell">
+    <table-column show="producedblocks" :label="$t('Forged blocks')" header-class="left-header-cell hidden xl:table-cell" cell-class="py-3 px-4 text-left border-none hidden xl:table-cell">
       <template slot-scope="row">
-        {{ readableCrypto(totalForged(row)) }}
+        {{ row.producedblocks }}
       </template>
     </table-column>
 
@@ -67,17 +67,7 @@ export default {
     },
   },
 
-  computed: {
-    ...mapGetters('delegates', ['forged'])
-  },
-
   methods: {
-    totalForged(delegate) {
-      delegate = this.forged.find(d => d.delegate === delegate.publicKey)
-
-      return delegate ? delegate.forged : 0
-    },
-
     lastForgingTime(delegate) {
       const lastBlock = delegate.forgingStatus.lastBlock
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -47,6 +47,7 @@
   "Rank": "Rank",
   "Name": "Name",
   "Forged": "Forged",
+  "Forged blocks": "Forged blocks",
   "Last Forged": "Last Forged",
   "Status": "Status",
   "Productivity": "Productivity",


### PR DESCRIPTION
... and avoid making 51 requests at every timer refresh.

I started looking at #195 and although this does not concern activeDelegates method directly, it could help **a lot** reducing server requests.

To me, displaying forged blocks instead of arks makes sense, and we can still see forged arks in the delegate details.
Now tell me what you think 😃  