### PR TITLE
adds pluralization to 'from transactions'

### DIFF
--- a/src/components/monitor/LastBlock.vue
+++ b/src/components/monitor/LastBlock.vue
@@ -10,7 +10,7 @@
     <div class="hidden md:block">
       <div class="text-grey mb-2 min-w-0">{{ $t("Forged") }}</div>
       <div class="text-lg text-white truncate">
-        {{ $t("from transactions", { currency: readableCrypto(block.totalForged), transactions: block.numberOfTransactions }) }}
+        {{ readableCrypto(block.totalForged) }} {{ $tc("from transactions", block.numberOfTransactions, { count: block.numberOfTransactions }) }}
       </div>
     </div>
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -59,7 +59,7 @@
   "Not forging": "Not forging",
   "In queue for forging": "In queue for forging",
   "Last block": "Last block",
-  "from transactions": "{currency} from {transactions} transactions",
+  "from transactions": "from 0 transactions | from 1 transaction | from {count} transactions",
   "Total Forged (token)": "Total Forged ({token})",
   "Forging": "Forging",
   "Missing": "Missing",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -55,7 +55,7 @@
   "Not forging": "Niet aan het forgen",
   "In queue for forging": "In de rij om te forgen",
   "Last block": "Laatste block",
-  "from transactions": "{currency} van {transactions} transacties",
+  "from transactions": "van 0 transacties | van 1 transactie | van {count} transacties",
   "Total Forged (token)": "Totaal geforged ({token})",
   "Forging": "Aan het forgen",
   "Missing": "Missend",


### PR DESCRIPTION
through this, the last-block component displays the singularized/pluralized form of `transactions` based on the count.

![image](https://user-images.githubusercontent.com/6547002/40655181-d29c6e30-6340-11e8-8636-0b270bf06d4d.png)
![image](https://user-images.githubusercontent.com/6547002/40655121-9ee76720-6340-11e8-9bd6-862dfe293202.png)
![image](https://user-images.githubusercontent.com/6547002/40655160-c1632e6a-6340-11e8-861b-cbf689bc674b.png)

