### PR TITLE
Avoid unnecessary request in delegate get all

### DIFF
--- a/src/services/delegate.js
+++ b/src/services/delegate.js
@@ -15,9 +15,10 @@ class DelegateService {
     })
 
     const requests = []
+    requests.push(response)
 
     for (
-      let index = 0;
+      let index = 1;
       index < Math.ceil(response.data.totalCount / activeDelegates);
       index++
     ) {


### PR DESCRIPTION
We were calling it twice to get the delegates from 1 to 51. Related to #195 