### PR TITLE
Fix issue with missed block not being colored correctly

### DIFF
--- a/src/components/monitor/ActiveDelegates.vue
+++ b/src/components/monitor/ActiveDelegates.vue
@@ -80,7 +80,7 @@ export default {
         '1': this.$i18n.t('Missing'),
         '2': this.$i18n.t('Not Forging'),
         '3': this.$i18n.t('Awaiting Slot'),
-        '4': this.$i18n.t('Awaiting Slot'),
+        '4': this.$i18n.t('Missed block, Awaiting Slot'),
         '5': this.$i18n.t('Not Forging'),
       }[row.forgingStatus.code]
 
@@ -102,7 +102,7 @@ export default {
         '1': '#f6993f', // Missing
         '2': '#ef192d', // Not Forging
         '3': '#838a9b', // Awaiting Slot
-        '4': '#838a9b', // Awaiting Slot
+        '4': '#f6993f', // Missed in previous round, now awaiting Slot
         '5': '#ef192d', // Not Forging
       }[row.forgingStatus.code]
     }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -63,6 +63,7 @@
   "Total Forged (token)": "Total Forged ({token})",
   "Forging": "Forging",
   "Missing": "Missing",
+  "Missed block, Awaiting Slot": "Missed block, Awaiting Slot",
   "Not Forging": "Not Forging",
   "Awaiting Slot": "Awaiting Slot",
 

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -59,6 +59,7 @@
   "Total Forged (token)": "Totaal geforged ({token})",
   "Forging": "Aan het forgen",
   "Missing": "Missend",
+  "Missed block, Awaiting Slot": "Block gemist, Wachten op plek",
   "Not Forging": "Niet aan het forgen",
   "Awaiting Slot": "Wachten op een plek",
 


### PR DESCRIPTION
Status 1 and 4 both indicate a block being missed, either in current round (1) or previous round (4). However, status 4 was not being colored yellow, but grey instead (such as the regular "awaiting spot" is colored). This PR changes the color to be yellow too (coincidentally there was 1 delegate missing a block):

![schermafbeelding 2018-05-29 om 19 50 47](https://user-images.githubusercontent.com/35610748/40676014-b0363f86-6379-11e8-8e90-3a886aa169ce.png)

Closes #216 