### PR TITLE
Add box shadow on block navigation button

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -330,7 +330,7 @@ thead th {
 
 .pager-button:enabled:hover,
 .block-pager-button:enabled:hover {
-  @apply .bg-blue .text-white
+  @apply .bg-blue .text-white .hover-button-shadow-definition
 }
 
 .block-pager-button {


### PR DESCRIPTION
Adds a box shadow to be in line with other blue buttons:

From this:
![schermafbeelding 2018-05-29 om 20 56 11](https://user-images.githubusercontent.com/35610748/40679435-63c49620-6383-11e8-8b66-76117d2d45e4.png)

To this:
![schermafbeelding 2018-05-29 om 20 59 30](https://user-images.githubusercontent.com/35610748/40679438-64c6d3e4-6383-11e8-98ec-0fdfee46e690.png)
