### PR TITLE
prevents the linebreak between date and time in tx and block tables

### DIFF
--- a/src/components/tables/Blocks.vue
+++ b/src/components/tables/Blocks.vue
@@ -13,7 +13,7 @@
         </template>
       </table-column>
 
-      <table-column show="timestamp" :label="$t('Timestamp')" header-class="left-header-cell" cell-class="left-cell">
+      <table-column show="timestamp" :label="$t('Timestamp')" header-class="left-header-cell" cell-class="left-cell whitespace-no-wrap">
         <template slot-scope="row">
           {{ readableTimestamp(row.timestamp) }}
         </template>

--- a/src/components/tables/Transactions.vue
+++ b/src/components/tables/Transactions.vue
@@ -7,7 +7,7 @@
         </template>
       </table-column>
 
-      <table-column show="timestamp" :label="$t('Timestamp')" header-class="left-header-cell hidden md:table-cell" cell-class="left-cell hidden md:table-cell">
+      <table-column show="timestamp" :label="$t('Timestamp')" header-class="left-header-cell hidden md:table-cell" cell-class="left-cell hidden md:table-cell whitespace-no-wrap">
         <template slot-scope="row">
           {{ readableTimestamp(row.timestamp) }}
         </template>


### PR DESCRIPTION
prevents this from happening:

![image](https://user-images.githubusercontent.com/6547002/40683090-ba836b94-638d-11e8-8a78-4bde98ca3dfe.png)
