### PR TITLE
adds 'truncateWhere' param to truncate()

### DIFF
--- a/src/components/tables/Transactions.vue
+++ b/src/components/tables/Transactions.vue
@@ -27,7 +27,7 @@
 
       <table-column show="vendorField" :label="$t('Smartbridge')" header-class="right-header-cell hidden lg:table-cell" cell-class="right-cell hidden lg:table-cell">
         <template slot-scope="row">
-          {{ truncate(row.vendorField || '', 35) }}
+          {{ truncate(row.vendorField || '', 35, 'right') }}
         </template>
       </table-column>
 

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -54,12 +54,28 @@ const methods = {
     return typeof compareTime !== 'undefined' ? momentTime.from(getTime(compareTime)) : momentTime.fromNow();
   },
 
-  truncate(value, length = 13) {
-    const odd = length % 2;
-    const truncationLength = Math.floor((length - 1) / 2);
-    return (value.length > length)
-      ? `${value.slice(0, truncationLength - odd)}...${value.slice(value.length - truncationLength + 1)}`
-      : value
+  truncate(value, length = 13, truncateWhere = 'middle') {
+    switch (truncateWhere) {
+      case 'left':
+        return (value.length > length)
+          ? `...${value.slice(value.length - length + 3)}`
+          : value
+
+      case 'middle':
+        const odd = length % 2;
+        const truncationLength = Math.floor((length - 1) / 2);
+        return (value.length > length)
+          ? `${value.slice(0, truncationLength - odd)}...${value.slice(value.length - truncationLength + 1)}`
+          : value
+
+      case 'right':
+        return (value.length > length)
+          ? `${value.slice(0, length - 3)}...`
+          : value
+
+      default:
+        return value
+    }
   },
 
   rawCurrency(value, currencyName) {

--- a/test/unit/specs/mixins/truncate.spec.js
+++ b/test/unit/specs/mixins/truncate.spec.js
@@ -3,6 +3,9 @@ import mixins from '@/mixins'
 describe('truncate mixin', () => {
   it('should properly format the given data', () => {
     expect(mixins.truncate('Hello World', 8)).toEqual('Hel...ld')
+    expect(mixins.truncate('Hello World', 8, 'left')).toEqual('...World')
+    expect(mixins.truncate('Hello World', 8, 'middle')).toEqual('Hel...ld')
+    expect(mixins.truncate('Hello World', 8, 'right')).toEqual('Hello...')
     expect(mixins.truncate('ThisIsA24CharacterString', 24)).toEqual('ThisIsA24CharacterString')
     expect(mixins.truncate('ThisIsA24CharacterString', 23)).toEqual('ThisIsA24C...cterString')
     expect(mixins.truncate('&ThisIsA25CharacterString', 24)).toEqual('&ThisIsA25C...cterString')


### PR DESCRIPTION
this use useful in cases we want to truncate a text from the right (or left), e.g. the smartbridge value in the transaction table, and want to have a fixed length.

the other option to truncate from the right would be to use the `.truncate` css class on the parent container, but that way the object in question would fill up all the available space.

the default behavior is to truncate in the middle.