### PR TITLE
adds missing transaction types to link-wallet component

### DIFF
--- a/src/components/links/Wallet.vue
+++ b/src/components/links/Wallet.vue
@@ -1,7 +1,7 @@
 <template>
   <span>
     <span class="hidden md:inline-block">
-      <router-link v-if="![1, 2, 3].includes(type)" :to="{ name: 'wallet', params: { address: walletAddress } }">
+      <router-link v-if="!type" :to="{ name: 'wallet', params: { address: walletAddress } }">
         <span v-if="isKnown">{{ knownWallets[address] }}</span>
         <span v-else-if="delegate">{{ delegate.username }}</span>
         <span v-else-if="hasDefaultSlot"><slot></slot></span>
@@ -11,10 +11,15 @@
       <span v-if="type === 1">{{ $t("2nd Signature Registration") }}</span>
       <span v-else-if="type === 2">{{ $t("Delegate Registration") }}</span>
       <span v-else-if="type === 3">{{ $t("Vote") }}</span>
+      <span v-else-if="type === 4">{{ $t("Multisignature Registration") }}</span>
+      <span v-else-if="type === 5">{{ $t("IPFS") }}</span>
+      <span v-else-if="type === 6">{{ $t("Timelock Transfer") }}</span>
+      <span v-else-if="type === 7">{{ $t("Multipayment") }}</span>
+      <span v-else-if="type === 8">{{ $t("Delegate Resignation") }}</span>
     </span>
 
     <span class="md:hidden">
-      <router-link v-if="![1, 2, 3].includes(type)" :to="{ name: 'wallet', params: { address: walletAddress } }">
+      <router-link v-if="!type" :to="{ name: 'wallet', params: { address: walletAddress } }">
         <span v-if="isKnown">{{ knownWallets[address] }}</span>
         <span v-else-if="delegate">{{ delegate.username }}</span>
         <span v-else-if="address">{{ truncate(address) }}</span>
@@ -23,6 +28,11 @@
       <span v-if="type === 1">{{ $t("2nd Signature Registration") }}</span>
       <span v-else-if="type === 2">{{ $t("Delegate Registration") }}</span>
       <span v-else-if="type === 3">{{ $t("Vote") }}</span>
+      <span v-else-if="type === 4">{{ $t("Multisignature Registration") }}</span>
+      <span v-else-if="type === 5">{{ $t("IPFS") }}</span>
+      <span v-else-if="type === 6">{{ $t("Timelock Transfer") }}</span>
+      <span v-else-if="type === 7">{{ $t("Multipayment") }}</span>
+      <span v-else-if="type === 8">{{ $t("Delegate Resignation") }}</span>
     </span>
   </span>
 </template>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -117,5 +117,10 @@
 
   "2nd Signature Registration": "2nd Signature Registration",
   "Delegate Registration": "Delegate Registration",
-  "Vote": "Vote"
+  "Vote": "Vote",
+  "Multisignature Registration": "Multisignature Registration",
+  "IPFS": "IPFS",
+  "Timelock Transfer": "Timelock Transfer",
+  "Multipayment": "Multipayment",
+  "Delegate Resignation": "Delegate Resignation"
 }

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -118,5 +118,5 @@
   "IPFS": "IPFS",
   "Timelock Transfer": "Timelock Transfer",
   "Multipayment": "Multipayment",
-  "Delegate Resignation": "Ontslag Afgevaardigde"
+  "Delegate Resignation": "Aftreden Afgevaardigde"
 }

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -113,5 +113,10 @@
 
   "2nd Signature Registration": "Registratie 2e Handtekening",
   "Delegate Registration": "Registratie Afgevaardigde",
-  "Vote": "Stem"
+  "Vote": "Stem",
+  "Multisignature Registration": "Registratie Multisignature",
+  "IPFS": "IPFS",
+  "Timelock Transfer": "Timelock Transfer",
+  "Multipayment": "Multipayment",
+  "Delegate Resignation": "Ontslag Afgevaardigde"
 }


### PR DESCRIPTION
as can be seen [here](https://explorer.ark.io/transaction/2d8ed494d852880eb674c279fad64468bfccadd79d2a63cc69a5ca80116933f5) for example, some transaction types were not considered in the link-wallet component, leaving the "recipient" field empty. the missing [transaction types](https://github.com/ArkEcosystem/AIPs/blob/master/AIPS/aip-11.md#payloads) were added.

these are mostly placeholders, transaction type 4 is the only new one for which there actually are transactions.

if someone who speaks dutch wants to confirm the durch translations that be great :)