### PR TITLE
Renamed ACF wallet to ARK Community Fund

### DIFF
--- a/networks/mainnet.json
+++ b/networks/mainnet.json
@@ -33,7 +33,7 @@
     "AeUyEH2UGpYrwHAupBh7syFhWYSBNFAkap": "OKEx",
     "AN4YrhvXUCLwL4wtts1FuWupbitKkwo91G": "Upbit",
     "AcVHEfEmFJkgoyuNczpgyxEA3MZ747DRAu": "Livecoin",
-    "AWkBFnqvCF4jhqPSdE2HBPJiwaf67tgfGR": "ACF"
+    "AWkBFnqvCF4jhqPSdE2HBPJiwaf67tgfGR": "ARK Community Fund"
   },
   "defaults": {
     "currency": {


### PR DESCRIPTION
Since the ACF also has a delegate called 'acf', I thought it would be better to rename their wallet to ARK Community Fund. That way the search will not give a different result for ACF vs acf