### PR TITLE
Added tooltip with confirmations to well confirmed

### DIFF
--- a/src/components/tables/TransactionsDetail.vue
+++ b/src/components/tables/TransactionsDetail.vue
@@ -47,7 +47,9 @@
               <img class="icon flex-none" src="@/assets/images/icons/clock.svg" />
             </div>
             <div v-else>
-              {{ $t("Well Confirmed") }}
+              <div v-tooltip="row.confirmations + ' ' + $t('Confirmations')">
+                {{ $t("Well Confirmed") }}
+              </div>
             </div>
           </div>
         </template>


### PR DESCRIPTION
Adds a tooltip with the amount of confirmations if it is listed as "well confirmed":

![schermafbeelding 2018-05-30 om 19 52 46](https://user-images.githubusercontent.com/35610748/40738432-d9daba40-6443-11e8-8af2-cfcd56d5a37a.png)

Change is only added to large screens currently, as we won't be able to see the tooltips properly on mobile devices anyway.