### PR TITLE
aligns h2 with h1 on block and wallet page

### DIFF
--- a/src/components/block/Transactions.vue
+++ b/src/components/block/Transactions.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="transactions.length > 0">
-    <h2 class="text-2xl mb-5 md:mb-6 px-10 sm:hidden text-theme-text-primary">{{ $t("Transactions") }}</h2>
+    <h2 class="text-2xl mb-5 md:mb-6 px-5 sm:hidden text-theme-text-primary">{{ $t("Transactions") }}</h2>
     <section class="page-section py-8">
       <div class="hidden sm:block">
         <table-transactions :transactions="transactions"></table-transactions>

--- a/src/components/wallet/Transactions.vue
+++ b/src/components/wallet/Transactions.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <h2 class="text-2xl mb-5 md:mb-6 px-10 sm:hidden text-theme-text-primary">{{ $t("Transactions") }}</h2>
+    <h2 class="text-2xl mb-5 md:mb-6 px-5 sm:hidden text-theme-text-primary">{{ $t("Transactions") }}</h2>
     <section class="page-section py-8">
       <nav class="mx-5 md:mx-10 mb-8 border-b flex items-end">
         <div


### PR DESCRIPTION
the h2 tag ("Transactions") currently has a bigger margin than the h1 ("Wallet Summary") above, e.g.

![image](https://user-images.githubusercontent.com/6547002/40741167-10187622-644b-11e8-9f47-b4a23bb198fb.png)
this looks and feels kinda off. this pr aligns the h2 with the h1.