### PR TITLE
disables public view button if public key does not exist on wallet page

### DIFF
--- a/src/components/wallet/Details.vue
+++ b/src/components/wallet/Details.vue
@@ -54,6 +54,7 @@
       <div class="flex-none px-8">
         <button
           @click="view = 'public'"
+          :disabled="!wallet.publicKey"
           :class="[view === 'public' ? 'bg-blue-darker' : 'bg-transparent text-blue-light', 'py-3 px-3 rounded-md text-white font-normal text-xs hover:text-blue']">
           <svg
             class="block"

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -106,6 +106,11 @@ input:focus {
   outline: none;
 }
 
+button:disabled {
+  cursor: default;
+  color: #838a9b !important;
+}
+
 .semibold {
   font-family: 'Proxima Nova Semibold';
 }
@@ -335,11 +340,6 @@ thead th {
 
 .block-pager-button {
   @apply .py-4 .px-5 .bg-transparent .bg-blue-darker .rounded-md .text-white .font-normal .text-xs
-}
-
-.block-pager-button:disabled {
-  cursor: default;
-  color: #838a9b;
 }
 
 /** Menu */


### PR DESCRIPTION
wallet pages for wallets without a public key, e.g. [AVytUqMWmdEhEY5gtcjoAPu88p5CtVBHid](http://localhost:8080/#/wallets/AVytUqMWmdEhEY5gtcjoAPu88p5CtVBHid), still display the button to switch to the public view, i.e. the address. this button has no function without the private view button counterpart, and should be disabled.

hiding the button all together looks off imo:

![image](https://user-images.githubusercontent.com/6547002/40743952-503edef0-6453-11e8-884a-f2a53f069969.png)

instead the the button is disabled, the color is set to grey and the cursor changed to default:

![image](https://user-images.githubusercontent.com/6547002/40743990-755e4f7c-6453-11e8-8524-ae42c123d104.png)
