### PR TITLE
Fix fee moving outside of screen

### DIFF
--- a/src/components/tables/Transactions.vue
+++ b/src/components/tables/Transactions.vue
@@ -60,10 +60,8 @@ export default {
 </script>
 
 <style>
-  @media(max-width: 815px) {
-    .wrap-timestamp {
-      white-space: normal;
-    }
+  .wrap-timestamp {
+    white-space: normal;
   }
 
   @media(min-width: 815px) {

--- a/src/components/tables/Transactions.vue
+++ b/src/components/tables/Transactions.vue
@@ -7,7 +7,7 @@
         </template>
       </table-column>
 
-      <table-column show="timestamp" :label="$t('Timestamp')" header-class="left-header-cell hidden md:table-cell" cell-class="left-cell hidden md:table-cell whitespace-no-wrap">
+      <table-column show="timestamp" :label="$t('Timestamp')" header-class="left-header-cell hidden md:table-cell" cell-class="left-cell hidden md:table-cell wrap-timestamp">
         <template slot-scope="row">
           {{ readableTimestamp(row.timestamp) }}
         </template>
@@ -31,7 +31,7 @@
         </template>
       </table-column>
 
-      <table-column show="amount" :label="$t('Amount (token)', {token: networkToken()})" header-class="right-header-end-cell md:pr-4" cell-class="right-end-cell md:pr-4">
+      <table-column show="amount" :label="$t('Amount (token)', {token: networkToken()})" header-class="right-header-end-cell lg:pr-4" cell-class="right-end-cell lg:pr-4">
         <template slot-scope="row">
           <span class="whitespace-no-wrap">
             <transaction-amount :transaction="row" :type="row.type"></transaction-amount>
@@ -39,7 +39,7 @@
         </template>
       </table-column>
 
-      <table-column show="fee" :label="$t('Fee (token)', {token: networkToken()})" header-class="right-header-end-cell hidden md:table-cell" cell-class="right-end-cell hidden md:table-cell">
+      <table-column show="fee" :label="$t('Fee (token)', {token: networkToken()})" header-class="right-header-end-cell hidden lg:table-cell" cell-class="right-end-cell hidden lg:table-cell">
         <template slot-scope="row">
           {{ readableCrypto(row.fee) }}
         </template>
@@ -58,3 +58,17 @@ export default {
   }
 }
 </script>
+
+<style>
+  @media(max-width: 815px) {
+    .wrap-timestamp {
+      white-space: normal;
+    }
+  }
+
+  @media(min-width: 815px) {
+    .wrap-timestamp {
+      white-space: nowrap;
+    }
+  }
+</style>


### PR DESCRIPTION
After PR #222 , the 'fee' column in the transactions table is off-screen on tablets:

![wrap-issue](https://user-images.githubusercontent.com/35610748/40745836-db74a0e0-6458-11e8-862c-eb15fbb2d97b.png)

This PR fixes the issue by making the timestamps' `no-wrap` conditional with media queries. This ensure that the timestamps still wrap on smaller screens, but also makes sure that they only wrap at a point where all of them wrap at the same time (so we don't end up with the same issue as before; which was some timestamps wrapping while others didn't). I also removed the visibility of the 'fee' column from `md` to `lg` screens, as there simply was no space for it.