### PR TITLE
displays chart tooltip with 8 decimals for cryptocurrencies

### DIFF
--- a/src/components/ChartWrapper.vue
+++ b/src/components/ChartWrapper.vue
@@ -103,14 +103,13 @@ export default {
         callbacks: {
           title: tooltipItem => {
             const name = store.getters['currency/name']
-            const symbol = store.getters['currency/symbol']
             const token = store.getters['currency/symbol']
 
             if ([token, 'BTC', 'ETH', 'LTC'].some(c => name.indexOf(c) > -1)) {
-              return `${symbol} ${Number(tooltipItem[0].yLabel).toFixed(8)} ${name}`
+              return `${name} ${Number(tooltipItem[0].yLabel).toFixed(8)}`
             }
 
-            return `${symbol} ${Number(tooltipItem[0].yLabel).toFixed(2)} ${name}`
+            return `${name} ${Number(tooltipItem[0].yLabel).toFixed(2)}`
           },
           label: tooltipItem => ''
           // label: tooltipItem => `BTC ${tooltipItem.yLabel}`

--- a/src/components/ChartWrapper.vue
+++ b/src/components/ChartWrapper.vue
@@ -104,6 +104,11 @@ export default {
           title: tooltipItem => {
             const name = store.getters['currency/name']
             const symbol = store.getters['currency/symbol']
+            const token = store.getters['currency/symbol']
+
+            if ([token, 'BTC', 'ETH', 'LTC'].some(c => name.indexOf(c) > -1)) {
+              return `${symbol} ${Number(tooltipItem[0].yLabel).toFixed(8)} ${name}`
+            }
 
             return `${symbol} ${Number(tooltipItem[0].yLabel).toFixed(2)} ${name}`
           },

--- a/src/components/ChartWrapper.vue
+++ b/src/components/ChartWrapper.vue
@@ -164,9 +164,6 @@ export default {
           data: response.datasets
         }],
       }
-
-      let maxY = Math.max(...this.chartData.datasets[0].data);
-      this.options.scales.yAxes[0].ticks.suggestedMax = maxY + 0.01;
     },
 
     watchCurrencyName() {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6547002/40754239-8985552a-6478-11e8-8e53-76194256de52.png)

the tooltips currently show the currency symbol and the respective ISO code - what do you think about showing only either one?

furthermore i removed the changes introduced with #159 and #160, i'll upon an issue for that.