### PR TITLE
fixes menu not being shown for small to large devices

### DIFF
--- a/src/components/header/menu/Mobile.vue
+++ b/src/components/header/menu/Mobile.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul class="menu-container w-full max-w-480px bg-table-row list-reset absolute pin-b pin-l py-5 block md:hidden">
+  <ul class="menu-container w-full max-w-480px bg-table-row list-reset absolute pin-b pin-l py-5 block xl:hidden">
     <li :class="[nightMode ? 'hover:bg-grey-dark' : 'hover:bg-grey-light', 'flex justify-center']">
       <router-link :to="{ name: 'home' }" tag="div" class="cursor-pointer py-5 w-64 flex-none border-b border-theme-nav-border">{{ $t("Home") }}</router-link>
     </li>


### PR DESCRIPTION
the mobile menu would be hidden for small devices, without the default menu to appear. the menu now follows the same behavior of the currency menu (visible if screensize smaller than `xl`).