### PR TITLE
fixes navigation on the wallet block pages

### DIFF
--- a/src/components/wallet/Details.vue
+++ b/src/components/wallet/Details.vue
@@ -166,7 +166,7 @@ export default {
 
   methods: {
     async getSendCount() {
-      const response = await TransactionService.sendByAddressCount(this.wallet.address)
+      const response = await TransactionService.sentByAddressCount(this.wallet.address)
       this.sendCount = response
     },
 

--- a/src/pages/Wallet/Blocks.vue
+++ b/src/pages/Wallet/Blocks.vue
@@ -8,7 +8,7 @@
       <div class="sm:hidden">
         <table-blocks-mobile :blocks="blocks"></table-blocks-mobile>
       </div>
-      <paginator :start="+this.page"></paginator>
+      <paginator :start="+this.page" :count="totalBlocks"></paginator>
     </section>
   </div>
 </template>
@@ -18,10 +18,14 @@ import WalletService from '@/services/wallet'
 import BlockService from '@/services/block'
 
 export default {
-  data: () => ({ blocks: [] }),
+  data: () => ({
+    totalBlocks: 0,
+    blocks: []
+  }),
 
   created() {
     this.$on('paginatorChanged', page => this.changePage(page))
+    this.getTotalBlocks()
   },
 
   async beforeRouteEnter (to, from, next) {
@@ -39,6 +43,7 @@ export default {
       const wallet = await WalletService.find(to.params.address)
       const blocks = await BlockService.getByPublicKey(wallet.publicKey, to.params.page)
       this.setBlocks(blocks)
+      next()
     } catch(e) { next({ name: '404' }) }
   },
 
@@ -56,6 +61,13 @@ export default {
       if (!blocks) return
 
       this.blocks = blocks
+    },
+
+    async getTotalBlocks() {
+      const wallet = await WalletService.find(this.address)
+      const response = await BlockService.forgedByPublicKeyCount(wallet.publicKey)
+
+      this.totalBlocks = Number(response)
     },
 
     changePage(page) {

--- a/src/pages/Wallet/Transactions.vue
+++ b/src/pages/Wallet/Transactions.vue
@@ -77,7 +77,7 @@ export default {
 
     async getSentCount() {
       const wallet = await WalletService.find(this.address)
-      const response = await TransactionService.sendByAddressCount(wallet.address)
+      const response = await TransactionService.sentByAddressCount(wallet.address)
       this.totalTransactions += Number(response)
     },
 

--- a/src/services/block.js
+++ b/src/services/block.js
@@ -67,6 +67,18 @@ class BlockService {
     return response.data.blocks
   }
 
+  async forgedByPublicKeyCount(generatorPublicKey) {
+    const response = await NodeService.get('blocks', {
+      params: {
+        generatorPublicKey,
+        limit: 1
+      }
+    })
+
+    // currently not supported by node
+    return response.data.count
+  }
+
   async lastBlockByPublicKey(publicKey) {
     const response = await NodeService.get('blocks', {
       params: {

--- a/src/services/transaction.js
+++ b/src/services/transaction.js
@@ -95,7 +95,7 @@ class TransactionService {
     return response.data.transactions
   }
 
-  async sendByAddressCount(senderId) {
+  async sentByAddressCount(senderId) {
     const response = await NodeService.get('transactions', {
       params: {
         senderId,


### PR DESCRIPTION
when navigating through a [wallets blocks](https://explorer.ark.io/wallets/ARAq9nhjCxwpWnGKDgxveAJSijNG8Y6dFQ/blocks/1), the url does not change.

this pr also sets the scaffold in place to disable the "next" button when we are on the last page, which is based on the total count of blocks. right now the api does not return the count when fetching blocks, as is the case for transactions for example.

and renames sendByAddressCount() to sentByAddressCount()