### PR TITLE
hides 'See all' link if there are no voters

### DIFF
--- a/src/components/wallet/Delegate.vue
+++ b/src/components/wallet/Delegate.vue
@@ -30,7 +30,7 @@
     <div class="list-row-border-b">
       <div>{{ $t("Blocks") }}</div>
       <div>
-        <span :class="[ !delegate.missedblocks ? 'mr-2' : '' ]">{{ delegate.producedblocks }}</span>
+        <span :class="[ !delegate.missedblocks && delegate.producedblocks ? 'mr-2' : '' ]">{{ delegate.producedblocks }}</span>
         <span v-if="!!delegate.missedblocks" class="text-grey mr-2">({{ delegate.missedblocks }} {{ $t("missed") }})</span>
         <router-link v-if="delegate.producedblocks > 0" :to="{ name: 'wallet-blocks', params: { address: delegate.address, page: 1 } }">{{ $t("See all") }}</router-link>
       </div>

--- a/src/components/wallet/Voters.vue
+++ b/src/components/wallet/Voters.vue
@@ -2,8 +2,8 @@
   <div class="border-t list-row" v-show="Object.keys(voters).length">
     <div>{{ $t("Voters") }}</div>
     <div>
-      <span v-tooltip="{ content: $t('Only voters with more than 0.1 Ark'), placement: 'left' }" class="mr-2">{{ voters.length }}</span>
-      <router-link v-if="wallet.address" :to="{ name: 'wallet-voters', params: { address: wallet.address, username: username, page: 1 } }">{{ $t("See all") }}</router-link>
+      <span v-tooltip="{ content: $t('Only voters with more than 0.1 Ark'), placement: 'left' }" :class="voters.length ? 'mr-2' : ''">{{ voters.length }}</span>
+      <router-link v-if="wallet.address && voters.length" :to="{ name: 'wallet-voters', params: { address: wallet.address, username: username, page: 1 } }">{{ $t("See all") }}</router-link>
     </div>
   </div>
 </template>


### PR DESCRIPTION
the link is currently shown, even if there are [no voters](https://explorer.ark.io/wallets/Ad5KLz71iNDxrT7d6P5mF6wcjeFR1atJrA).

simply hiding the link is one option, not displaying the whole row is the other (as is done when the wallet is not voting for example).