### PR TITLE
Add lint rule to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,9 @@ node_js:
   - 'stable'
   - '8'
 
+install:
+  - npm install
+
 script:
+  - npm run lint
   - npm run build


### PR DESCRIPTION
Build will probably fail due to lint issues that are fixed with #245

Edit: question: is the `install: - npm install` option still necessary for travis? I don't see it do much different compared to before