### PR TITLE
add vote weight on hover for delegate listing

### DIFF
--- a/src/components/monitor/ActiveDelegates.vue
+++ b/src/components/monitor/ActiveDelegates.vue
@@ -49,7 +49,7 @@
 
     <table-column show="approval" :label="$t('Approval')" header-class="right-header-cell pr-5 md:pr-10 hidden md:table-cell" cell-class="py-3 px-4 md:pr-10 text-right border-none hidden md:table-cell">
       <template slot-scope="row">
-        <span v-tooltip="{ content: readableCrypto(row.vote, true, 2), placement: 'left' }">
+        <span v-tooltip="{ content: readableCrypto(row.vote, true, 2), placement: 'top' }">
           {{ percentageString(row.approval) }}
         </span>
       </template>

--- a/src/components/monitor/ActiveDelegates.vue
+++ b/src/components/monitor/ActiveDelegates.vue
@@ -49,7 +49,9 @@
 
     <table-column show="approval" :label="$t('Approval')" header-class="right-header-cell pr-5 md:pr-10 hidden md:table-cell" cell-class="py-3 px-4 md:pr-10 text-right border-none hidden md:table-cell">
       <template slot-scope="row">
-        {{ percentageString(row.approval) }}
+        <span v-tooltip="{ content: readableCrypto(row.vote, true, 2), placement: 'left' }">
+          {{ percentageString(row.approval) }}
+        </span>
       </template>
     </table-column>
   </table-component>

--- a/src/components/monitor/StandbyDelegates.vue
+++ b/src/components/monitor/StandbyDelegates.vue
@@ -20,7 +20,9 @@
 
     <table-column show="approval" :label="$t('Approval')" header-class="right-header-cell sm:pr-10 hidden md:table-cell" cell-class="right-end-cell hidden md:table-cell w-40">
       <template slot-scope="row">
-        {{ percentageString(row.approval) }}
+        <span v-tooltip="{ content: readableCrypto(row.vote, true, 2), placement: 'left' }">
+          {{ percentageString(row.approval) }}
+        </span>
       </template>
     </table-column>
   </table-component>

--- a/src/components/monitor/StandbyDelegates.vue
+++ b/src/components/monitor/StandbyDelegates.vue
@@ -20,7 +20,7 @@
 
     <table-column show="approval" :label="$t('Approval')" header-class="right-header-cell sm:pr-10 hidden md:table-cell" cell-class="right-end-cell hidden md:table-cell w-40">
       <template slot-scope="row">
-        <span v-tooltip="{ content: readableCrypto(row.vote, true, 2), placement: 'left' }">
+        <span v-tooltip="{ content: readableCrypto(row.vote, true, 2), placement: 'top' }">
           {{ percentageString(row.approval) }}
         </span>
       </template>


### PR DESCRIPTION
Add vote weight on hover for active and standby delegate listings. 

Vote weight is already displayed on the delegate wallet page.

Feature preview:

![explorer_hover_final](https://user-images.githubusercontent.com/15830979/40840078-739dd358-65a5-11e8-97e5-10c38f1196b7.png)


