### PR TITLE
adds label icon to transaction link component

### DIFF
--- a/src/components/links/Transaction.vue
+++ b/src/components/links/Transaction.vue
@@ -2,7 +2,22 @@
   <span v-tooltip="sanitizedVendorfield">
     <router-link :to="{ name: 'transaction', params: { id } }" class="hidden md:inline-block whitespace-no-wrap">
       <span v-if="hasDefaultSlot"><slot></slot></span>
-      <span v-else>{{ truncate(id) }}</span>
+      <div v-else class="flex">
+        <span>{{ truncate(id) }}</span>
+        <svg
+         v-if="smartBridge && showSmartBridgeIcon"
+         class="ml-2 fill-current"
+         xmlns="http://www.w3.org/2000/svg"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         width="18px" height="18px">
+        <path fill-rule="evenodd" fill="currentColor"
+          d="M17.6,11.3c0.6-0.6,0.6-1.5,0-2l-6.7-6.5C10.6,2.4,10,2.2,9.6,2.2H5.5C4.7,2.3,3.9,2.9,3.9,3.8l0,0C3.8,3.8,3.6,3.9,3.4,4
+          C2.5,4.3,1.6,5,0.9,5.5l0,0c-1,1-0.9,1.8-0.7,2.3c0.1,0.3,0.6,0.9,2,0.9c0.6,0,1.2-0.1,1.9-0.2c0,0.3,0.1,0.6,0.3,0.7l6.7,6.7
+          c0.6,0.6,1.5,0.6,2,0L17.6,11.3z M8,6.1c-0.5,0.5-1.1,0.5-1.6,0c0,0,0,0-0.1-0.1c-0.5,0.3-1,0.7-1.6,0.9c-2,0.9-3.4,0.7-3.5,0.3
+          c0-0.1,0-0.5,0.5-0.9l0,0c0.6-0.6,1.2-1,2.1-1.4h0.1v1.6c0.2-0.1,0.3-0.2,0.6-0.2c0.6-0.2,1.1-0.6,1.6-0.8c0-0.3,0.1-0.7,0.3-1
+          c0.5-0.5,1.1-0.5,1.6,0C8.4,5,8.4,5.7,8,6.1z"/>
+        </svg>
+      </div>
     </router-link>
     <router-link :to="{ name: 'transaction', params: { id } }" class="md:hidden whitespace-no-wrap">
       <span>{{ truncate(id) }}</span>
@@ -23,6 +38,10 @@ export default {
       type: String,
       required: false,
     },
+    showSmartBridgeIcon: {
+      type: Boolean,
+      required: false
+    }
   },
 
   computed: {

--- a/src/components/tables/TransactionsDetail.vue
+++ b/src/components/tables/TransactionsDetail.vue
@@ -3,7 +3,7 @@
     <table-component :data="transactions" sort-by="timestamp" sort-order="desc" :show-filter="false" :show-caption="false" table-class="w-full">
       <table-column show="id" :label="$t('ID')" header-class="left-header-start-cell" cell-class="left-start-cell">
         <template slot-scope="row">
-          <link-transaction :id="row.id" :smart-bridge="row.vendorField"></link-transaction>
+          <link-transaction :id="row.id" :smart-bridge="row.vendorField" :show-smart-bridge-icon="true"></link-transaction>
         </template>
       </table-column>
 


### PR DESCRIPTION
the transaction detail component, as opposed to the other table components, is missing the smartbridge column / value and there is no indication to *whether* there is something in the vendor field or not, other than by hovering over the transaction id. this pr adds a little label icon to the transaction link component to indicate that.

![image](https://user-images.githubusercontent.com/6547002/40839256-fda7faf0-65a1-11e8-91fe-3968e0aa91d7.png)
