### PR TITLE
fixes table row background on hover

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -143,7 +143,7 @@ tbody tr:nth-child(even) {
 }
 
 tbody tr:hover {
-  background-color: rgba(0, 0, 0, 0);
+  background-color: var(--color-theme-table-row-hover);
   transform: scale(1.015);
   box-shadow: var(--theme-table-hover-shadow);
   z-index: 999;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6547002/40885973-38a23d5c-6730-11e8-9cb3-515ef99887ab.png)

the background of the table row was set to `transparent` on hover. this value should be set to `var(--color-theme-table-row-hover)`.

even after setting the correct value, there is still a very subtle visible border, which is however caused by the scaling of the element.

![image](https://user-images.githubusercontent.com/6547002/40886062-aad1c432-6731-11e8-861c-d3bd584e2807.png)
