### PR TITLE
Change timestamp wrapping due to smartbridge icon

### DIFF
--- a/src/components/tables/Transactions.vue
+++ b/src/components/tables/Transactions.vue
@@ -64,7 +64,7 @@ export default {
     white-space: normal;
   }
 
-  @media(min-width: 815px) {
+  @media(min-width: 870px) {
     .wrap-timestamp {
       white-space: nowrap;
     }


### PR DESCRIPTION
Due to the addition of the smartbridge label / icon, the table was going off screen again