### PR TITLE
Change top accounts to top wallets

### DIFF
--- a/src/pages/TopWallets.vue
+++ b/src/pages/TopWallets.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="max-w-2xl mx-auto md:pt-5">
-    <content-header>{{ $t("Top Accounts") }}</content-header>
+    <content-header>{{ $t("Top Wallets") }}</content-header>
     <section class="page-section py-5 md:py-10">
       <div class="hidden sm:block">
         <table-wallets :wallets="wallets" :total="supply"></table-wallets>


### PR DESCRIPTION
The phrase `Top Wallets` was used everywhere, except for the page itself where `Top Accounts` was used. This PR makes it more consistent by using `Top Wallets` on the page too.