### PR TITLE
Disable all html in v-tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "lodash": "^4.17.10",
     "moment": "^2.22.1",
     "qrious": "^4.0.2",
-    "sanitize-html": "^1.18.2",
     "v-tooltip": "^2.0.0-rc.32",
     "vue": "^2.5.16",
     "vue-chartjs": "^3.3.1",

--- a/src/components/links/Transaction.vue
+++ b/src/components/links/Transaction.vue
@@ -1,5 +1,5 @@
 <template>
-  <span v-tooltip="sanitizedVendorfield">
+  <span v-tooltip="smartBridge">
     <router-link :to="{ name: 'transaction', params: { id } }" class="hidden md:inline-block whitespace-no-wrap">
       <span v-if="hasDefaultSlot"><slot></slot></span>
       <div v-else-if="showSmartBridgeIcon" class="flex">
@@ -45,7 +45,6 @@
 </template>
 
 <script type="text/ecmascript-6">
-import sanitizeHtml from 'sanitize-html'
 
 export default {
   props: {
@@ -66,12 +65,6 @@ export default {
   computed: {
     hasDefaultSlot() {
       return !!this.$slots.default
-    },
-    sanitizedVendorfield() {
-      if (this.smartBridge !== undefined) {
-        return sanitizeHtml(this.smartBridge)
-      }
-      return ""
     }
   },
 }

--- a/src/main.js
+++ b/src/main.js
@@ -28,7 +28,7 @@ new Vue({
   template: '<App/>',
 })
 
-Vue.use(VTooltip)
+Vue.use(VTooltip, { defaultHtml: false })
 
 /** Sortable Tables */
 TableComponent.settings({


### PR DESCRIPTION
@alexbarnsley as talked about on slack.

I've added a default to not allow html anywhere the tooltip is used. If someone really needs to show HTML, then it should be explicitly allowed for that particular instance. Also removed the sanitizeHtml package as we no longer need it.

Before:
![schermafbeelding 2018-06-04 om 18 32 09](https://user-images.githubusercontent.com/35610748/40930129-1820f54e-6827-11e8-9261-ea0699c43414.png)

After:
![schermafbeelding 2018-06-04 om 18 31 59](https://user-images.githubusercontent.com/35610748/40930142-1f0ffe90-6827-11e8-9857-0523acc0a170.png)

