### PR TITLE
Increased limit for block call to 50

### DIFF
--- a/src/services/transaction.js
+++ b/src/services/transaction.js
@@ -24,7 +24,7 @@ class TransactionService {
     const response = await NodeService.get('transactions', {
       params: {
         blockId: id,
-        limit: 25
+        limit: 50
       }
     })
     return response.data.transactions


### PR DESCRIPTION
Max amount of transactions in a block is 50 atm, but the explorer only retrieves 25 max (see [this block](https://explorer.ark.io/block/3836330521713919332) for an example). This PR increases the limit to 50 so all the transactions will be shown as a temporary? solution.

Better solution would be to work with pagination and offsets for these transactions too, especially if they might increase in the future. 