### PR TITLE
fixes padding in block identity component

### DIFF
--- a/src/components/block/Identity.vue
+++ b/src/components/block/Identity.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="mb-5 bg-theme-feature-background xl:rounded-lg flex flex-col md:flex-row items-center px-10 py-8">
+  <section class="mb-5 bg-theme-feature-background xl:rounded-lg flex flex-col md:flex-row items-center px-5 sm:px-10 py-8">
     <div class="flex items-center flex-auto w-full md:w-auto mb-5 md:mb-0">
       <img class="mr-6" src="@/assets/images/icons/block.svg" />
       <div class="flex-auto min-w-0">


### PR DESCRIPTION
the padding used was non-responsive and too big on small devices

![image](https://user-images.githubusercontent.com/6547002/41019340-737a48ea-695e-11e8-86ad-bf0615ec9941.png)
