### PR TITLE
Fix return value of votes function

### DIFF
--- a/src/services/transaction.js
+++ b/src/services/transaction.js
@@ -129,18 +129,6 @@ class TransactionService {
     return response.data.count
   }
 
-  async votes(senderId) {
-    const response = await NodeService.get('transactions', {
-      params: {
-        orderBy: 'timestamp:desc',
-        limit: 25,
-        type: 3,
-        senderId
-      }
-    })
-    return response.data.transactions
-  }
-
   async paginate(page, limit = 25) {
     const offset = (page > 1) ? (page - 1) * limit : 0
 

--- a/src/services/transaction.js
+++ b/src/services/transaction.js
@@ -138,7 +138,7 @@ class TransactionService {
         senderId
       }
     })
-    return response.data
+    return response.data.transactions
   }
 
   async paginate(page, limit = 25) {


### PR DESCRIPTION
All the other functions returned a specific property, instead of the full data, so I've added that for the `votes` function too.

However, since it is not used and does not return the votes for a given address at the moment, it might be even better if we just remove it until v2? @faustbrian 