### PR TITLE
Removed undefined parameter from inside activeDelegates

### DIFF
--- a/src/services/delegate.js
+++ b/src/services/delegate.js
@@ -186,7 +186,7 @@ class DelegateService {
     })
 
     // Forging Status
-    const height = await block.height(status)
+    const height = await block.height()
     return { delegateCount: delegateCount,
       delegates: delegatesRounds.map(delegate => {
         delegate.forgingStatus = forging.status(


### PR DESCRIPTION
`BlockService.height()` does not take a parameter, and `status` was undefined anyway, so I removed it