### PR TITLE
Remove redundant check in search functions

### DIFF
--- a/src/services/search.js
+++ b/src/services/search.js
@@ -3,27 +3,27 @@ import NodeService from '@/services/node'
 class SearchService {
   async findByAddress(address) {
     const response = await NodeService.get('accounts', {params: {address}})
-    return response.data.success ? response.data : false
+    return response.data
   }
 
   async findByUsername(username) {
     const response = await NodeService.get('delegates/get', {params: {username}})
-    return response.data.success ? response.data : false
+    return response.data
   }
 
   async findByPublicKey(publicKey) {
     const response = await NodeService.get('delegates/get', {params: {publicKey}})
-    return response.data.success ? response.data : false
+    return response.data
   }
 
   async findByBlockId(id) {
     const response = await NodeService.get('blocks/get', {params: {id}})
-    return response.data.success ? response.data : false
+    return response.data
   }
 
   async findByTransactionId(id) {
     const response = await NodeService.get('transactions/get', {params: {id}})
-    return response.data.success ? response.data : false
+    return response.data
   }
 }
 


### PR DESCRIPTION
The `NodeService` already checks for `response.data.success` and throws an error if `!success`, which is handled by the `try..catch` statements in the `search.vue` file.

TL;DR the check is redundant as it can not occur