### PR TITLE
add comma separator to readableNumber function

### DIFF
--- a/src/components/monitor/ActiveDelegates.vue
+++ b/src/components/monitor/ActiveDelegates.vue
@@ -18,7 +18,7 @@
 
     <table-column show="producedblocks" :label="$t('Forged blocks')" header-class="left-header-cell hidden xl:table-cell" cell-class="py-3 px-4 text-left border-none hidden xl:table-cell">
       <template slot-scope="row">
-        {{ row.producedblocks }}
+        {{ readableNumber(row.producedblocks, 0, true) }}
       </template>
     </table-column>
 

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -91,8 +91,12 @@ const methods = {
       })
   },
 
-  readableNumber(value, digits = 2) {
-    return value.toFixed(digits)
+  readableNumber(value, digits = 2, separator = false) {
+    if (!separator) {
+      return value.toFixed(digits)
+    }
+
+    return value.toFixed(digits).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
   },
 
   readableFiat(value) {

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -96,7 +96,7 @@ const methods = {
       return value.toFixed(digits)
     }
 
-    return value.toFixed(digits).toLocaleString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+    return value.toLocaleString(undefined, { minimumFractionDigits: digits })
   },
 
   readableFiat(value) {

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -96,7 +96,7 @@ const methods = {
       return value.toFixed(digits)
     }
 
-    return value.toFixed(digits).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+    return value.toFixed(digits).toLocaleString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
   },
 
   readableFiat(value) {

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -96,7 +96,10 @@ const methods = {
       return value.toFixed(digits)
     }
 
-    return value.toLocaleString(undefined, { minimumFractionDigits: digits })
+    return value.toLocaleString(undefined, {
+      minimumFractionDigits: digits,
+      maximumFractionDigits: digits,
+    })
   },
 
   readableFiat(value) {


### PR DESCRIPTION
add comma seperator to readableNumber function and integrate it to forged blocks by delegate

![explorer_comma](https://user-images.githubusercontent.com/15830979/41534676-a1535d2e-72ff-11e8-8bde-0eff193c562f.png)

