### PR TITLE
fix: updated waiting for element to make e2e more robust

### DIFF
--- a/test/e2e/specs/blocks.js
+++ b/test/e2e/specs/blocks.js
@@ -63,9 +63,9 @@ module.exports = {
 
   'it should be possible to click on the block id': function (browser) {
     browser
-      .useCss()
-      .waitForElementVisible('div.table-component')
-      .useXpath().click("//tbody[contains(@class, 'table-component__table__body')]//tr[1]//td[1]//a[1]")
+      .useXpath()
+      .waitForElementVisible("//tbody[contains(@class, 'table-component__table__body')]//tr[1]//td[1]//a[1]")
+      .click("//tbody[contains(@class, 'table-component__table__body')]//tr[1]//td[1]//a[1]")
       .pause(500)
     browser
       .useCss()

--- a/test/e2e/specs/delegate-monitor.js
+++ b/test/e2e/specs/delegate-monitor.js
@@ -143,9 +143,9 @@ module.exports = {
 
   'it should be possible to click on the standby delegates name': function (browser) {
     browser
-      .useCss()
-      .waitForElementVisible('div.table-component')
-      .useXpath().click("//tbody[contains(@class, 'table-component__table__body')]//tr[1]//td[2]//a[1]")
+      .useXpath()
+      .waitForElementVisible("//tbody[contains(@class, 'table-component__table__body')]//tr[1]//td[2]//a[1]")
+      .click("//tbody[contains(@class, 'table-component__table__body')]//tr[1]//td[2]//a[1]")
       .pause(500)
     browser
       .useCss()

--- a/test/e2e/specs/homepage.js
+++ b/test/e2e/specs/homepage.js
@@ -124,27 +124,44 @@ module.exports = {
     browser
       .url(devServer)
       .waitForElementVisible('main.theme-light')
+      .waitForElementVisible('button.border-transparent')
       .click('button.border-transparent')
 
     browser
-      .useXpath().click("//button[contains(., 'Top Wallets')]")
-      .pause(1000)
+      .useXpath()
+      .waitForElementVisible("//button[contains(., 'Top Wallets')]")
+      .click("//button[contains(., 'Top Wallets')]")
+      .pause(500)
+      
+    browser
+      .useCss()
+      .waitForElementVisible('div.table-component')
       .assert.urlContains('/top-wallets')
   },
 
   'from menu, it should be possible to navigate to delegate monitor': function(browser) {
     browser
       .useCss().click('button.border-transparent')
-      .useXpath().click("//button[contains(., 'Delegate Monitor')]")
-      .pause(1000)
+      .useXpath()
+      .waitForElementVisible("//button[contains(., 'Delegate Monitor')]")
+      .click("//button[contains(., 'Delegate Monitor')]")
+      .pause(500)
+    browser
+      .useCss()
+      .waitForElementVisible('div.table-component')
       .assert.urlContains('/delegate-monitor')
   },
 
   'from menu, it should be possible to navigate back to homepage': function(browser) {
     browser
       .useCss().click('button.border-transparent')
-      .useXpath().click("//button[contains(., 'Home')]")
-      .pause(1000)
+      .useXpath()
+      .waitForElementVisible("//button[contains(., 'Home')]")
+      .click("//button[contains(., 'Home')]")
+      .pause(500)
+    browser
+      .useCss()
+      .waitForElementVisible('div.table-component')
       .assert.urlContains('/#')
   },
 

--- a/test/e2e/specs/transactions.js
+++ b/test/e2e/specs/transactions.js
@@ -101,10 +101,10 @@ module.exports = {
     browser
       .url(devServer)
       .waitForElementVisible('main.theme-light')
-      .waitForElementVisible('.table-component__table__body')
-      .pause(500)
+      .useXpath()
+      .waitForElementVisible("//tbody[contains(@class, 'table-component__table__body')]//tr[1]//td[4]//a[1]")
     browser
-      .useXpath().click("//tbody[contains(@class, 'table-component__table__body')]//tr[1]//td[4]//a[1]")
+      .click("//tbody[contains(@class, 'table-component__table__body')]//tr[1]//td[4]//a[1]")
       .pause(500)
     browser
       .useCss()


### PR DESCRIPTION
There were some e2e tests that could fail if an element didn't load quickly enough. Changed some of the `waitForElementVisible` statements to ensure that the element is visible before trying to click it