### PR TITLE
feat: close menu when clicking on current page item

### DIFF
--- a/src/components/header/menu/Desktop.vue
+++ b/src/components/header/menu/Desktop.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="absolute pin px-4 md:px-8 hidden sm:flex bg-theme-nav-background xl:rounded-r-md">
     <button
-      @click="$store.dispatch('ui/setMenuVisible', false)"
+      @click="closeMenu"
       class='px-4 py-3 md:py-6 flex-none flex items-center border-b-2 margin-t-2 mr-3 border-transparent hover:border-red text-theme-text-secondary'>
       <!-- Inline this SVG so we can change color dynamically -->
       <svg
@@ -13,9 +13,9 @@
       </svg>
     </button>
 
-    <router-link :to="{ name: 'home' }" tag="button" class="menu-button">{{ $t("Home") }}</router-link>
-    <router-link :to="{ name: 'top-wallets', params: { page: 1 } }" tag="button" class="menu-button">{{ $t("Top Wallets") }}</router-link>
-    <router-link :to="{ name: 'delegate-monitor' }" tag="button" class="menu-button">{{ $t("Delegate Monitor") }}</router-link>
+    <router-link @click.native="closeMenu" :to="{ name: 'home' }" tag="button" class="menu-button">{{ $t("Home") }}</router-link>
+    <router-link @click.native="closeMenu" :to="{ name: 'top-wallets', params: { page: 1 } }" tag="button" class="menu-button">{{ $t("Top Wallets") }}</router-link>
+    <router-link @click.native="closeMenu" :to="{ name: 'delegate-monitor' }" tag="button" class="menu-button">{{ $t("Delegate Monitor") }}</router-link>
     <!-- <router-link :to="{ name: 'statistics' }" tag="button" class="menu-button">Statistics</router-link> -->
 
     <div class="flex-auto"></div>
@@ -26,3 +26,14 @@
     </a> -->
   </div>
 </template>
+
+<script type="text/ecmascript-6">
+
+export default {
+  methods: {
+    closeMenu() {
+      this.$store.dispatch('ui/setMenuVisible', false)
+    }
+  }
+}
+</script>


### PR DESCRIPTION
When opening the menu, it will now also close when you click on an item when you were already on that page. 