### PR TITLE
imp: show loader in delegate monitor tables

### DIFF
--- a/src/components/monitor/ActiveDelegates.vue
+++ b/src/components/monitor/ActiveDelegates.vue
@@ -3,58 +3,63 @@
     <span class="hidden sm:inline-block">Rank</span>
     <span class="sm:hidden">#</span>
   </th> -->
-  <table-component :data="delegates" sort-by="rate" sort-order="asc" :show-filter="false" :show-caption="false" table-class="w-full text-xs md:text-base">
-    <table-column show="rate" :label="$t('Rank')" header-class="p-4 pl-5 sm:pl-10 text-left w-32" cell-class="p-3 pl-5 sm:pl-10 text-left border-none">
-      <template slot-scope="row">
-        {{ row.rate }}
-      </template>
-    </table-column>
+  <loader :data="delegates">
+    <table-component v-if="delegates && delegates.length > 0" :data="delegates" sort-by="rate" sort-order="asc" :show-filter="false" :show-caption="false" table-class="w-full text-xs md:text-base">
+      <table-column show="rate" :label="$t('Rank')" header-class="p-4 pl-5 sm:pl-10 text-left w-32" cell-class="p-3 pl-5 sm:pl-10 text-left border-none">
+        <template slot-scope="row">
+          {{ row.rate }}
+        </template>
+      </table-column>
 
-    <table-column show="username" :label="$t('Name')" header-class="left-header-cell" cell-class="py-3 px-4 text-left border-none">
-      <template slot-scope="row">
-        <link-wallet :address="row.address"></link-wallet>
-      </template>
-    </table-column>
+      <table-column show="username" :label="$t('Name')" header-class="left-header-cell" cell-class="py-3 px-4 text-left border-none">
+        <template slot-scope="row">
+          <link-wallet :address="row.address"></link-wallet>
+        </template>
+      </table-column>
 
-    <table-column show="producedblocks" :label="$t('Forged blocks')" header-class="left-header-cell hidden xl:table-cell" cell-class="py-3 px-4 text-left border-none hidden xl:table-cell">
-      <template slot-scope="row">
-        {{ readableNumber(row.producedblocks, 0, true) }}
-      </template>
-    </table-column>
+      <table-column show="producedblocks" :label="$t('Forged blocks')" header-class="left-header-cell hidden xl:table-cell" cell-class="py-3 px-4 text-left border-none hidden xl:table-cell">
+        <template slot-scope="row">
+          {{ readableNumber(row.producedblocks, 0, true) }}
+        </template>
+      </table-column>
 
-    <table-column show="blocksAt" :label="$t('Last Forged')" header-class="left-header-cell hidden sm:table-cell" cell-class="py-3 px-4 text-left border-none hidden sm:table-cell">
-      <template slot-scope="row">
-        {{ lastForgingTime(row) }}
-      </template>
-    </table-column>
+      <table-column show="blocksAt" :label="$t('Last Forged')" header-class="left-header-cell hidden sm:table-cell" cell-class="py-3 px-4 text-left border-none hidden sm:table-cell">
+        <template slot-scope="row">
+          {{ lastForgingTime(row) }}
+        </template>
+      </table-column>
 
-    <table-column sort-by="status" show="forgingStatus" :label="$t('Status')" header-class="base-header-cell pr-5 sm:pr-10 md:pr-4 w-24 md:w-auto" cell-class="py-3 px-4 pr-5 sm:pr-10 md:pr-4 text-center border-none">
-      <template slot-scope="row">
-        <svg
-         xmlns="http://www.w3.org/2000/svg"
-         xmlns:xlink="http://www.w3.org/1999/xlink"
-         width="19px" height="19px"
-         v-tooltip="statusMessage(row)">
-        <path fill-rule="evenodd" :fill="statusColor(row)"
-         d="M9.500,-0.000 C14.746,-0.000 18.999,4.253 18.999,9.500 C18.999,14.747 14.746,19.000 9.500,19.000 C4.253,19.000 -0.001,14.747 -0.001,9.500 C-0.001,4.253 4.253,-0.000 9.500,-0.000 Z"/>
-        </svg>
-      </template>
-    </table-column>
+      <table-column sort-by="status" show="forgingStatus" :label="$t('Status')" header-class="base-header-cell pr-5 sm:pr-10 md:pr-4 w-24 md:w-auto" cell-class="py-3 px-4 pr-5 sm:pr-10 md:pr-4 text-center border-none">
+        <template slot-scope="row">
+          <svg
+           xmlns="http://www.w3.org/2000/svg"
+           xmlns:xlink="http://www.w3.org/1999/xlink"
+           width="19px" height="19px"
+           v-tooltip="statusMessage(row)">
+          <path fill-rule="evenodd" :fill="statusColor(row)"
+           d="M9.500,-0.000 C14.746,-0.000 18.999,4.253 18.999,9.500 C18.999,14.747 14.746,19.000 9.500,19.000 C4.253,19.000 -0.001,14.747 -0.001,9.500 C-0.001,4.253 4.253,-0.000 9.500,-0.000 Z"/>
+          </svg>
+        </template>
+      </table-column>
 
-    <table-column show="productivity" :label="$t('Productivity')" header-class="right-header-cell hidden md:table-cell" cell-class="py-3 px-4 text-right border-none hidden md:table-cell">
-      <template slot-scope="row">
-        {{ percentageString(row.productivity) }}
-      </template>
-    </table-column>
+      <table-column show="productivity" :label="$t('Productivity')" header-class="right-header-cell hidden md:table-cell" cell-class="py-3 px-4 text-right border-none hidden md:table-cell">
+        <template slot-scope="row">
+          {{ percentageString(row.productivity) }}
+        </template>
+      </table-column>
 
-    <table-column show="approval" :label="$t('Approval')" header-class="right-header-cell pr-5 md:pr-10 hidden md:table-cell" cell-class="py-3 px-4 md:pr-10 text-right border-none hidden md:table-cell">
-      <template slot-scope="row">
-        <span v-tooltip="{ content: readableCrypto(row.vote, true, 2), placement: 'top' }">
-          {{ percentageString(row.approval) }}
-        </span>
-      </template>
-    </table-column>
-  </table-component>
+      <table-column show="approval" :label="$t('Approval')" header-class="right-header-cell pr-5 md:pr-10 hidden md:table-cell" cell-class="py-3 px-4 md:pr-10 text-right border-none hidden md:table-cell">
+        <template slot-scope="row">
+          <span v-tooltip="{ content: readableCrypto(row.vote, true, 2), placement: 'top' }">
+            {{ percentageString(row.approval) }}
+          </span>
+        </template>
+      </table-column>
+    </table-component>
+    <div v-else class="px-5 md:px-10">
+      <span>{{ $t("No Results") }}</span>
+    </div>
+  </loader>
 </template>
 
 <script type="text/ecmascript-6">
@@ -64,7 +69,7 @@ import moment from 'moment'
 export default {
   props: {
     delegates: {
-      type: Array,
+      // type: Array, or null
       required: true,
     },
   },

--- a/src/components/monitor/Forging.vue
+++ b/src/components/monitor/Forging.vue
@@ -50,7 +50,7 @@ import ForgingService from '@/services/forging'
 export default {
   props: {
     delegates: {
-      type: Array,
+      // type: Array or null
       required: true,
     },
   },

--- a/src/components/monitor/StandbyDelegates.vue
+++ b/src/components/monitor/StandbyDelegates.vue
@@ -1,31 +1,36 @@
 <template>
-  <table-component :data="delegates" sort-by="approval" sort-order="desc" :show-filter="false" :show-caption="false" table-class="w-full text-xs md:text-base">
-    <table-column show="rate" :label="$t('Rank')" header-class="left-header-cell pl-5 sm:pl-10 w-32" cell-class="p-3 pl-5 sm:pl-10 text-left border-none">
-      <template slot-scope="row">
-        {{ row.rate }}
-      </template>
-    </table-column>
+  <loader :data="delegates">
+    <table-component v-if="delegates && delegates.length > 0" :data="delegates" sort-by="approval" sort-order="desc" :show-filter="false" :show-caption="false" table-class="w-full text-xs md:text-base">
+      <table-column show="rate" :label="$t('Rank')" header-class="left-header-cell pl-5 sm:pl-10 w-32" cell-class="p-3 pl-5 sm:pl-10 text-left border-none">
+        <template slot-scope="row">
+          {{ row.rate }}
+        </template>
+      </table-column>
 
-    <table-column show="address" :label="$t('Name')" header-class="left-header-cell" cell-class="left-cell">
-      <template slot-scope="row">
-        <link-wallet :address="row.address"></link-wallet>
-      </template>
-    </table-column>
+      <table-column show="address" :label="$t('Name')" header-class="left-header-cell" cell-class="left-cell">
+        <template slot-scope="row">
+          <link-wallet :address="row.address"></link-wallet>
+        </template>
+      </table-column>
 
-    <table-column show="productivity" :label="$t('Productivity')" header-class="right-header-cell hidden md:table-cell" cell-class="right-cell hidden md:table-cell">
-      <template slot-scope="row">
-        {{ percentageString(row.productivity) }}
-      </template>
-    </table-column>
+      <table-column show="productivity" :label="$t('Productivity')" header-class="right-header-cell hidden md:table-cell" cell-class="right-cell hidden md:table-cell">
+        <template slot-scope="row">
+          {{ percentageString(row.productivity) }}
+        </template>
+      </table-column>
 
-    <table-column show="approval" :label="$t('Approval')" header-class="right-header-cell sm:pr-10 hidden md:table-cell" cell-class="right-end-cell hidden md:table-cell w-40">
-      <template slot-scope="row">
-        <span v-tooltip="{ content: readableCrypto(row.vote, true, 2), placement: 'top' }">
-          {{ percentageString(row.approval) }}
-        </span>
-      </template>
-    </table-column>
-  </table-component>
+      <table-column show="approval" :label="$t('Approval')" header-class="right-header-cell sm:pr-10 hidden md:table-cell" cell-class="right-end-cell hidden md:table-cell w-40">
+        <template slot-scope="row">
+          <span v-tooltip="{ content: readableCrypto(row.vote, true, 2), placement: 'top' }">
+            {{ percentageString(row.approval) }}
+          </span>
+        </template>
+      </table-column>
+    </table-component>
+    <div v-else class="px-5 md:px-10">
+      <span>{{ $t("No Results") }}</span>
+    </div>
+  </loader>
 </template>
 
 <script type="text/ecmascript-6">
@@ -34,7 +39,7 @@ import { mapGetters } from 'vuex'
 import moment from 'moment'
 
 export default {
-  data: () => ({ delegates: [] }),
+  data: () => ({ delegates: null }),
 
   computed: {
     ...mapGetters('network', ['activeDelegates']),

--- a/src/pages/DelegateMonitor.vue
+++ b/src/pages/DelegateMonitor.vue
@@ -43,7 +43,7 @@ export default {
   },
 
   data: () => ({
-    delegates: [],
+    delegates: null,
     delegateCount: null,
     activeTab: 'active',
     timer: null,

--- a/test/e2e/specs/transactions.js
+++ b/test/e2e/specs/transactions.js
@@ -63,9 +63,9 @@ module.exports = {
 
   'it should be possible to click on the transactions id': function (browser) {
     browser
-      .useCss()
-      .waitForElementVisible('div.table-component')
-      .useXpath().click("//tbody[contains(@class, 'table-component__table__body')]//tr[1]//td[1]//a[1]")
+      .useXpath()
+      .waitForElementVisible("//tbody[contains(@class, 'table-component__table__body')]//tr[1]//td[1]//a[1]")
+      .click("//tbody[contains(@class, 'table-component__table__body')]//tr[1]//td[1]//a[1]")
       .pause(500)
     browser
       .useCss()
@@ -82,9 +82,10 @@ module.exports = {
     browser
       .url(devServer)
       .waitForElementVisible('main.theme-light')
-      .waitForElementVisible('.table-component__table__body')
+      .useXpath()
+      .waitForElementVisible("//tbody[contains(@class, 'table-component__table__body')]//tr[1]//td[3]//a[1]")
     browser
-      .useXpath().click("//tbody[contains(@class, 'table-component__table__body')]//tr[1]//td[3]//a[1]")
+      .click("//tbody[contains(@class, 'table-component__table__body')]//tr[1]//td[3]//a[1]")
       .pause(500)
     browser
       .useCss()


### PR DESCRIPTION
Added a loader to the delegate monitor tables, as it currently shows `No Results` while waiting for the delegates to be loaded.

Probably best to look at the diff without whitespaces, due to the loader everything is indented slightly different 😬 
