### PR TITLE
feat: Added 2nd signature indicator on wallet page

### DIFF
--- a/src/components/wallet/Details.vue
+++ b/src/components/wallet/Details.vue
@@ -179,7 +179,6 @@ export default {
 
   methods: {
     async getSendCount() {
-      console.log(this.wallet)
       const response = await TransactionService.sentByAddressCount(this.wallet.address)
       this.sendCount = response
     },

--- a/src/components/wallet/Details.vue
+++ b/src/components/wallet/Details.vue
@@ -11,7 +11,20 @@
       <div
         v-if="view === 'public'"
         class="pr-8 flex-auto min-w-0">
-        <div class="text-grey mb-2">{{ $t("Address") }}</div>
+        <div class="text-grey mb-2">
+          {{ $t("Address") }}
+          <svg
+            v-tooltip="$t('Second Signature Enabled')"
+            v-if="wallet.secondSignature"
+            class="ml-1 fill-current"
+            viewBox="0 0 448 512"
+            xmlns="http://www.w3.org/2000/svg"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+            width="14px" height="14px">
+            <path fill-rule="evenodd" fill="currentColor" 
+            d="M400 224h-24v-72C376 68.2 307.8 0 224 0S72 68.2 72 152v72H48c-26.5 0-48 21.5-48 48v192c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V272c0-26.5-21.5-48-48-48zm-104 0H152v-72c0-39.7 32.3-72 72-72s72 32.3 72 72v72z"/>
+          </svg>
+        </div>
         <div class="flex">
           <div class="text-lg text-white semibold truncate">
             <span class="mr-2">{{ wallet.address }}</span>
@@ -166,6 +179,7 @@ export default {
 
   methods: {
     async getSendCount() {
+      console.log(this.wallet)
       const response = await TransactionService.sentByAddressCount(this.wallet.address)
       this.sendCount = response
     },

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -85,6 +85,7 @@
   "All": "All",
   "Sent": "Sent",
   "Received": "Received",
+  "Second Signature": "Second Signature Enabled",
 
   "Previous": "Previous",
   "Next": "Next",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -85,6 +85,7 @@
   "All": "Alles",
   "Sent": "Verzonden",
   "Received": "Ontvangen",
+  "Second Signature": "2e Handtekening Ingeschakeld",
 
   "Previous": "Vorige",
   "Next": "Volgende",


### PR DESCRIPTION
Adds an icon if second signature is enabled for a wallet

![schermafbeelding 2018-06-29 om 21 39 39](https://user-images.githubusercontent.com/35610748/42111527-11f79f98-7be5-11e8-9dfb-6bf3dfb52ebe.png)

Resolves #293 
