### PR TITLE
feat: Added page titles to routes

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -19,115 +19,137 @@ const NotFoundComponent = () => import('@/pages/404')
 
 Vue.use(Router)
 
+const titleSuffix = ' - ARK Explorer'
+
 const router = new Router({
   mode: process.env.ROUTER_MODE,
   routes: [
     {
       path: '/',
       name: 'home',
-      component: HomeComponent
+      component: HomeComponent,
+      meta: { title: route => { return 'Home' + titleSuffix } }
     },
     {
       path: '/wallets/:address',
       name: 'wallet',
-      component: WalletComponent
+      component: WalletComponent,
+      meta: { title: route => { return 'Wallet ' + route.params.address + titleSuffix } }
     },
     {
       path: '/wallets/:address/voters',
       redirect: to => ({
         name: 'wallet-voters',
         params: { address: to.params.address, page: 1 }
-      })
+      }),
+      meta: { title: route => { return 'Voters' + titleSuffix } }
     },
     {
       path: '/wallets/:address/voters/:page(\\d+)',
       name: 'wallet-voters',
-      component: WalletVotersComponent
+      component: WalletVotersComponent,
+      meta: { title: route => { return 'Voters' + titleSuffix } }
     },
     {
       path: '/wallets/:address/blocks',
       redirect: to => ({
         name: 'wallet-blocks',
         params: { address: to.params.address, page: 1 }
-      })
+      }),
+      meta: { title: route => { return 'Blocks' + titleSuffix } }
     },
     {
       path: '/wallets/:address/blocks/:page(\\d+)',
       name: 'wallet-blocks',
-      component: WalletBlocksComponent
+      component: WalletBlocksComponent,
+      meta: { title: route => { return 'Blocks' + titleSuffix } }
     },
     {
       path: '/wallets/:address/transactions',
       redirect: to => ({
         name: 'wallet-transactions',
         params: { address: to.params.address, type: 'all', page: 1 }
-      })
+      }),
+      meta: { title: route => { return 'Wallet Transactions' + titleSuffix } }
     },
     {
       path: '/wallets/:address/transactions/:type',
       redirect: to => ({
         name: 'wallet-transactions',
         params: { address: to.params.address, type: to.params.type, page: 1 }
-      })
+      }),
+      meta: { title: route => { return 'Wallet Transactions' + titleSuffix } }
     },
     {
       path: '/wallets/:address/transactions/:type/:page(\\d+)',
       name: 'wallet-transactions',
-      component: WalletTransactionsComponent
+      component: WalletTransactionsComponent,
+      meta: { title: route => { return 'Wallet Transactions' + titleSuffix } }
     },
     {
       path: '/block/:id',
       name: 'block',
-      component: BlockComponent
+      component: BlockComponent,
+      meta: { title: route => { return 'Block' + titleSuffix } }
     },
     {
       path: '/block/:id/transactions',
       redirect: to => ({
         name: 'block-transactions',
         params: { id: to.params.id, page: 1 }
-      })
+      }),
+      meta: { title: route => { return 'Block Transactions' + titleSuffix } }
     },
     {
       path: '/block/:id/transactions/:page(\\d+)',
       name: 'block-transactions',
-      component: BlockTransactionsComponent
+      component: BlockTransactionsComponent,
+      meta: { title: route => { return 'Block Transactions' + titleSuffix } }
     },
     {
       path: '/blocks',
-      redirect: to => ({ name: 'blocks', params: { page: 1 } })
+      redirect: to => ({ name: 'blocks', params: { page: 1 } }),
+      meta: { title: route => { return 'Blocks' + titleSuffix } }
     },
     {
       path: '/blocks/:page(\\d+)',
       name: 'blocks',
-      component: BlocksComponent
+      component: BlocksComponent,
+      meta: { title: route => { return 'Blocks' + titleSuffix } }
     },
     {
       path: '/transaction/:id',
       name: 'transaction',
-      component: TransactionComponent
+      component: TransactionComponent,
+      meta: { title: route => { return 'Transaction' + titleSuffix } }
     },
     {
       path: '/transactions',
-      redirect: to => ({ name: 'transactions', params: { page: 1 } })
+      redirect: to => ({ name: 'transactions', params: { page: 1 } }),
+      meta: { title: route => { return 'Transactions' + titleSuffix } }
     },
     {
       path: '/transactions/:page(\\d+)',
       name: 'transactions',
-      component: TransactionsComponent
+      component: TransactionsComponent,
+      meta: { title: route => { return 'Transactions' + titleSuffix } }
     },
     {
       path: '/delegate-monitor',
       name: 'delegate-monitor',
-      component: DelegateMonitorComponent
+      component: DelegateMonitorComponent,
+      meta: { title: route => { return 'Delegate Monitor' + titleSuffix } }
     },
     {
       path: 'top-wallets',
-      redirect: to => ({ name: 'top-wallets', params: { page: 1 } })
+      redirect: to => ({ name: 'top-wallets', params: { page: 1 } }),
+      meta: { title: route => { return 'Top Wallets' + titleSuffix } }
     },
     {
       path: '/top-wallets/:page(\\d+)',
       name: 'top-wallets',
-      component: TopWalletsComponent
+      component: TopWalletsComponent,
+      meta: { title: route => { return 'Top Wallets' + titleSuffix } }
     },
     // {
     //   path: '/statistics',
@@ -137,11 +159,13 @@ const router = new Router({
     {
       path: '404',
       name: '404',
-      component: NotFoundComponent
+      component: NotFoundComponent,
+      meta: { title: route => { return '404' + titleSuffix } }
     },
     {
       path: '*',
-      redirect: { name: '404' }
+      redirect: { name: '404' },
+      meta: { title: route => { return '404' + titleSuffix } }
     },
     // 2.0 fallback redirects...
     {
@@ -149,19 +173,26 @@ const router = new Router({
       redirect: to => ({
         name: 'wallet',
         params: { address: to.params.address }
-      })
-    }, {
+      }),
+      meta: { title: route => { return 'Wallet' + titleSuffix } }
+    },
+    {
       path: '/tx/:id',
       redirect: to => ({
         name: 'transaction',
         params: { id: to.params.id }
-      })
-    }, {
+      }),
+      meta: { title: route => { return 'Transaction' + titleSuffix } }
+    },
+    {
       path: '/delegateMonitor',
-      redirect: '/delegate-monitor'
-    }, {
+      redirect: '/delegate-monitor',
+      meta: { title: route => { return 'Delegate Monitor' + titleSuffix } }
+    },
+    {
       path: '/topAccounts',
-      redirect: to => ({ name: 'top-wallets', params: { page: 1 } })
+      redirect: to => ({ name: 'top-wallets', params: { page: 1 } }),
+      meta: { title: route => { return 'Top Wallets' + titleSuffix } }
     }
   ],
   scrollBehavior (to, from, savedPosition) {
@@ -176,6 +207,7 @@ const router = new Router({
 router.beforeEach((to, from, next) => {
   store.dispatch('ui/setHeaderType', null)
   store.dispatch('ui/setMenuVisible', false)
+  document.title = to.meta.title(to)
 
   next()
 })

--- a/test/e2e/specs/homepage.js
+++ b/test/e2e/specs/homepage.js
@@ -132,7 +132,7 @@ module.exports = {
       .waitForElementVisible("//button[contains(., 'Top Wallets')]")
       .click("//button[contains(., 'Top Wallets')]")
       .pause(500)
-      
+
     browser
       .useCss()
       .waitForElementVisible('div.table-component')


### PR DESCRIPTION
Adds the possibility to set titles for different pages. Currently it's the type of page (e.g. Home, Blocks, etc) and a default suffix of 'ARK Explorer'.

![schermafbeelding 2018-06-29 om 22 09 58](https://user-images.githubusercontent.com/35610748/42112892-b7cac3d8-7be9-11e8-8cff-85402922d004.png)

Resolves #295 