### PR TITLE
imp: updated checks on url to wait for more indicative elements first

### DIFF
--- a/test/e2e/specs/blocks.js
+++ b/test/e2e/specs/blocks.js
@@ -69,11 +69,9 @@ module.exports = {
       .pause(500)
     browser
       .useCss()
-      .waitForElementVisible('main.theme-light')
-      .assert.urlContains('/block/')
-    browser
       .waitForElementVisible('h1')
       .assert.containsText('h1', 'Block')
+      .assert.urlContains('/block/')
       .end()
   },
 

--- a/test/e2e/specs/delegate-monitor.js
+++ b/test/e2e/specs/delegate-monitor.js
@@ -43,11 +43,10 @@ module.exports = {
     browser
       .url(devServer)
       .useXpath()
-      .waitForElementVisible("//div[text() = 'Delegate']")
-      .pause(1000)
-    browser
+      .waitForElementVisible("//div[contains(@class, 'bg-theme-feature-background')]/div[3]//div[text() = 'Delegate']/following-sibling::div//a[1]")
       .click("//div[contains(@class, 'bg-theme-feature-background')]/div[3]//div[text() = 'Delegate']/following-sibling::div//a[1]")
       .pause(500)
+    browser
       .waitForElementVisible("//h1[text() = 'Wallet Summary']")
       .assert.urlContains('/wallets/')
   },
@@ -95,11 +94,9 @@ module.exports = {
       .pause(500)
     browser
       .useCss()
-      .waitForElementVisible('main.theme-light')
-      .assert.urlContains('/wallets/')
-    browser
       .waitForElementVisible('h1')
       .assert.containsText('h1', 'Wallet Summary')
+      .assert.urlContains('/wallets/')
   },
 
   'it should be possible to switch to standby delegates': function (browser) {
@@ -149,11 +146,9 @@ module.exports = {
       .pause(500)
     browser
       .useCss()
-      .waitForElementVisible('main.theme-light')
-      .assert.urlContains('/wallets/')
-    browser
       .waitForElementVisible('h1')
       .assert.containsText('h1', 'Wallet Summary')
+      .assert.urlContains('/wallets/')
     browser.end()
   }
 }

--- a/test/e2e/specs/transactions.js
+++ b/test/e2e/specs/transactions.js
@@ -69,11 +69,9 @@ module.exports = {
       .pause(500)
     browser
       .useCss()
-      .waitForElementVisible('main.theme-light')
-      .assert.urlContains('/transaction/')
-    browser
       .waitForElementVisible('h1')
       .assert.containsText('h1', 'Transaction')
+      .assert.urlContains('/transaction/')
   },
 
   'it should be possible to click on the sender': function (browser) {
@@ -89,11 +87,9 @@ module.exports = {
       .pause(500)
     browser
       .useCss()
-      .waitForElementVisible('main.theme-light')
-      .assert.urlContains('/wallets/')
-    browser
       .waitForElementVisible('h1')
       .assert.containsText('h1', 'Wallet Summary')
+      .assert.urlContains('/wallets/')
   },
 
   'it should be possible to click on the recipient': function (browser) {

--- a/test/e2e/specs/voters.js
+++ b/test/e2e/specs/voters.js
@@ -70,9 +70,8 @@ module.exports = {
       .click("//tbody[contains(@class, 'table-component__table__body')]//tr[1]//td[2]//a[1]")
       .pause(500)
     browser
-      .useCss()
-      .waitForElementVisible('h1')
-      .assert.containsText('h1', 'Wallet Summary')
+      .useXpath()
+      .waitForElementVisible("//h1[contains(.,'Wallet Summary')]")
       .assert.urlContains('/wallets/')
       .end()
   }

--- a/test/e2e/specs/voters.js
+++ b/test/e2e/specs/voters.js
@@ -65,17 +65,15 @@ module.exports = {
 
   'it should be possible to click on a wallet address': function (browser) {
     browser
-      .useCss()
-      .waitForElementVisible('div.table-component')
-      .useXpath().click("//tbody[contains(@class, 'table-component__table__body')]//tr[1]//td[2]//a[1]")
+      .useXpath()
+      .waitForElementVisible("//tbody[contains(@class, 'table-component__table__body')]//tr[1]//td[2]//a[1]")
+      .click("//tbody[contains(@class, 'table-component__table__body')]//tr[1]//td[2]//a[1]")
       .pause(500)
     browser
       .useCss()
-      .waitForElementVisible('main.theme-light')
-      .assert.urlContains('/wallets/')
-    browser
       .waitForElementVisible('h1')
       .assert.containsText('h1', 'Wallet Summary')
+      .assert.urlContains('/wallets/')
       .end()
   }
 }


### PR DESCRIPTION
Changed the checks on URLs to wait for more useful elements to be visible first, so it will no longer check too early and report a wrong URL
