### PR TITLE
Fixes error in ActiveDelegates.vue when 'lastBlock' is not available

### DIFF
--- a/src/components/monitor/ActiveDelegates.vue
+++ b/src/components/monitor/ActiveDelegates.vue
@@ -93,14 +93,12 @@ export default {
 
       const lastBlock = row.forgingStatus.lastBlock
 
-      const tooltip = {
+      return lastBlock ? {
         content: `[${status}] Last Block @ ${
             lastBlock.height
           } on ${this.readableTimestamp(lastBlock.timestamp)}`,
         classes: [`tooltip-bg-${row.forgingStatus.code}`, 'font-sans']
-      }
-
-      return lastBlock ? tooltip : status
+      } : status
     },
 
     statusColor(row) {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -66,6 +66,7 @@
   "Missed block, Awaiting Slot": "Missed block, Awaiting Slot",
   "Not Forging": "Not Forging",
   "Awaiting Slot": "Awaiting Slot",
+  "Never": "Never",
 
   "Address": "Address",
   "Public Key": "Public Key",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -66,6 +66,7 @@
   "Missed block, Awaiting Slot": "Block gemist, Wachten op plek",
   "Not Forging": "Niet aan het forgen",
   "Awaiting Slot": "Wachten op een plek",
+  "Never": "Nooit",
 
   "Address": "Adres",
   "Public Key": "Public Key",

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -66,6 +66,7 @@
   "Missed block, Awaiting Slot": "Bloco foi perdido, Aguardando Slot",
   "Not Forging": "Não está Forjando",
   "Awaiting Slot": "Aguardando Slot",
+  "Never": "Nunca",
 
   "Address": "Endereço",
   "Public Key": "Public Key",


### PR DESCRIPTION
Fixes #308. Trying to access `lastBlock.height` caused the row not to be displayed when there is no last block for a given delegate. Also adds the missing translations for `Never`.