### PR TITLE
fix: Updated OKEx wallet address

### DIFF
--- a/networks/mainnet.json
+++ b/networks/mainnet.json
@@ -30,7 +30,7 @@
     "ALgvTAoz5Vi9easHqBK6aEMKatHb4beCXm": "ARK Shield",
     "AUDud8tvyVZa67p3QY7XPRUTjRGnWQQ9Xv": "ARK Team",
     "AUexKjGtgsSpVzPLs6jNMM6vJ6znEVTQWK": "Bittrex",
-    "AeUyEH2UGpYrwHAupBh7syFhWYSBNFAkap": "OKEx",
+    "ARXhacG5MPdT1ehWPTPo8jtfC5NrS29eKS": "OKEx",
     "AN4YrhvXUCLwL4wtts1FuWupbitKkwo91G": "Upbit",
     "AcVHEfEmFJkgoyuNczpgyxEA3MZ747DRAu": "Livecoin",
     "AWkBFnqvCF4jhqPSdE2HBPJiwaf67tgfGR": "ARK Community Fund",


### PR DESCRIPTION
Recently OKEx moved their funds to a new wallet, this changes to a new address in Explorer.
