### PR TITLE
fix : Update Reward Offset with new Devnet config

### DIFF
--- a/networks/devnet.json
+++ b/networks/devnet.json
@@ -3,7 +3,7 @@
   "server": "https://dexplorer.ark.io:8443/api",
   "alias": "Development",
   "activeDelegates": 51,
-  "rewardOffset": 75600,
+  "rewardOffset": 10800,
   "currencies": [],
   "knownWallets": {},
   "defaults": {


### PR DESCRIPTION
Updating from previous Offset that started rewards at block 75,600 to new one that started at 10,800.
