### PR TITLE
Fixes margins of 'Show more' wrapper element

### DIFF
--- a/src/components/block/Transactions.vue
+++ b/src/components/block/Transactions.vue
@@ -8,7 +8,7 @@
       <div class="sm:hidden">
         <table-transactions-mobile :transactions="transactions"></table-transactions-mobile>
       </div>
-      <div class="mx-10 mt-10 flex flex-wrap" v-if="transactions.length >= 25">
+      <div class="mx-5 sm:mx-10 mt-5 md:mt-10 flex flex-wrap" v-if="transactions.length >= 25">
         <router-link :to="{ name: 'block-transactions', params: { block: this.block.id, page: 2 } }" tag="button" class="show-more-button">
           {{ $t("Show more") }}
         </router-link>

--- a/src/components/home/LatestBlocks.vue
+++ b/src/components/home/LatestBlocks.vue
@@ -7,7 +7,7 @@
       <div class="sm:hidden">
         <table-blocks-mobile :blocks="blocks"></table-blocks-mobile>
       </div>
-      <div class="mx-10 mt-10 flex flex-wrap">
+      <div class="mx-5 sm:mx-10 mt-5 md:mt-10 flex flex-wrap">
         <router-link :to="{ name: 'blocks', params: { page: 2 } }" tag="button" class="show-more-button">
           {{ $t("Show more") }}
         </router-link>

--- a/src/components/home/LatestTransactions.vue
+++ b/src/components/home/LatestTransactions.vue
@@ -7,7 +7,7 @@
       <div class="sm:hidden">
           <table-transactions-mobile :transactions="transactions"></table-transactions-mobile>
       </div>
-      <div class="mx-10 mt-10 flex flex-wrap">
+      <div class="mx-5 sm:mx-10 mt-5 md:mt-10 flex flex-wrap">
         <router-link :to="{ name: 'transactions', params: { page: 2 } }" tag="button" class="show-more-button">
           {{ $t("Show more") }}
         </router-link>

--- a/src/components/wallet/Transactions.vue
+++ b/src/components/wallet/Transactions.vue
@@ -34,7 +34,7 @@
       <div class="sm:hidden">
         <table-transactions-detail-mobile :transactions="transactions"></table-transactions-detail-mobile>
       </div>
-      <div class="mx-10 mt-10 flex flex-wrap" v-if="transactions && transactions.length >= 25">
+      <div class="mx-5 sm:mx-10 mt-5 md:mt-10 flex flex-wrap" v-if="transactions && transactions.length >= 25">
         <router-link :to="{ name: 'wallet-transactions', params: { address: this.wallet.address, type, page: 2 } }" tag="button" class="show-more-button">
           {{ $t("Show more") }}
         </router-link>


### PR DESCRIPTION
On smaller screens, the margins of the div containing the `Show more` buttons were too big. This PR sets the correct css classes, as used already in the paginator component.