### PR TITLE
Centers search icon on small displays

### DIFF
--- a/src/components/header/Default.vue
+++ b/src/components/header/Default.vue
@@ -17,7 +17,7 @@
         </svg>
         <span class="semibold">{{ $t("Menu") }}</span>
       </button>
-      <span class="border-r mx-4 lg:mx-6 my-4"></span>
+      <span class="border-r mx-2 md:mx-4 lg:mx-6 my-4"></span>
       <div class="flex-auto flex items-center justify-center">
         <label for="search" class="hidden">{{ $t("Search") }}</label>
         <input


### PR DESCRIPTION
The vertical line left of the search icon is missing some css classes causing the search icon to be off center when viewed on small displays.

![image](https://user-images.githubusercontent.com/6547002/44309524-49199480-a3c8-11e8-9e0f-a416265e874d.png)

Fixed:
![image](https://user-images.githubusercontent.com/6547002/44309532-749c7f00-a3c8-11e8-997d-27aea67621ae.png)
