### PR TITLE
Makes paddings in 'page-sections' more uniform

### DIFF
--- a/src/components/block/Details.vue
+++ b/src/components/block/Details.vue
@@ -1,6 +1,6 @@
 <template>
-  <section class="page-section py-8 mb-5">
-    <div class="px-5 sm:px-10 py-4">
+  <section class="page-section py-5 md:py-10 mb-5">
+    <div class="px-5 sm:px-10">
       <div class="list-row-border-b">
         <div>{{ $t("Transactions") }}</div>
         <div>{{ block.numberOfTransactions }}</div>

--- a/src/components/block/Transactions.vue
+++ b/src/components/block/Transactions.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="transactions && transactions.length > 0">
     <h2 class="text-2xl mb-5 md:mb-6 px-5 sm:hidden text-theme-text-primary">{{ $t("Transactions") }}</h2>
-    <section class="page-section py-8">
+    <section class="page-section py-5 md:py-10">
       <div class="hidden sm:block">
         <table-transactions :transactions="transactions"></table-transactions>
       </div>

--- a/src/components/wallet/Transactions.vue
+++ b/src/components/wallet/Transactions.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <h2 class="text-2xl mb-5 md:mb-6 px-5 sm:hidden text-theme-text-primary">{{ $t("Transactions") }}</h2>
-    <section class="page-section py-8">
+    <section class="page-section py-5 md:py-10">
       <nav class="mx-5 md:mx-10 mb-8 border-b flex items-end">
         <div
           @click="type = 'all'"

--- a/src/pages/404.vue
+++ b/src/pages/404.vue
@@ -2,7 +2,7 @@
   <div class="max-w-2xl mx-auto md:pt-5">
     <content-header>{{ $t("Ooops!") }}</content-header>
 
-    <section class="page-section py-10 px-6">
+    <section class="page-section py-5 md:py-10 px-6">
       <div class="my-10 text-center">
         <img
           v-if="!nightMode"

--- a/src/pages/Block/Transactions.vue
+++ b/src/pages/Block/Transactions.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="max-w-2xl mx-auto md:pt-5">
     <content-header>{{ $t("Transactions") }}</content-header>
-    <section class="page-section py-10">
+    <section class="page-section py-5 md:py-10">
       <div class="hidden sm:block">
         <table-transactions :transactions="transactions"></table-transactions>
       </div>

--- a/src/pages/Blocks.vue
+++ b/src/pages/Blocks.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="max-w-2xl mx-auto md:pt-5">
     <content-header>{{ $t("Blocks") }}</content-header>
-    <section class="page-section py-10">
+    <section class="page-section py-5 md:py-10">
       <div class="hidden sm:block">
         <table-blocks :blocks="blocks"></table-blocks>
       </div>

--- a/src/pages/DelegateMonitor.vue
+++ b/src/pages/DelegateMonitor.vue
@@ -4,7 +4,7 @@
 
     <delegate-detail :delegateCount="delegateCount"></delegate-detail>
 
-    <section class="page-section py-8">
+    <section class="page-section py-5 md:py-10">
       <nav class="mx-5 sm:mx-10 mb-4 border-b flex items-end">
         <div
           @click="activeTab = 'active'"

--- a/src/pages/Statistics.vue
+++ b/src/pages/Statistics.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="max-w-2xl mx-auto md:pt-5">
     <content-header>{{ $t("Statistics") }}</content-header>
-    <section class="page-section pt-10 pb-8">
+    <section class="page-section py-5 md:py-10">
       <nav class="mx-5 sm:mx-10 border-b flex items-end">
         <div
           @click="activeTab = 'transactions'"

--- a/src/pages/Transaction.vue
+++ b/src/pages/Transaction.vue
@@ -21,8 +21,8 @@
       </div>
     </section>
 
-    <section class="page-section py-8 mb-5">
-      <div class="px-5 sm:px-10 py-4">
+    <section class="page-section py-5 md:py-10 mb-5">
+      <div class="px-5 sm:px-10">
         <div class="list-row-border-b">
           <div>{{ $t("Sender") }}</div>
           <div class="truncate">

--- a/src/pages/Transactions.vue
+++ b/src/pages/Transactions.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="max-w-2xl mx-auto md:pt-5">
     <content-header>{{ $t("Transactions") }}</content-header>
-    <section class="page-section py-10">
+    <section class="page-section py-5 md:py-10">
       <div class="hidden sm:block">
         <table-transactions :transactions="transactions"></table-transactions>
       </div>

--- a/src/pages/Wallet.vue
+++ b/src/pages/Wallet.vue
@@ -4,8 +4,8 @@
 
     <wallet-details :wallet="wallet"></wallet-details>
 
-    <section class="page-section mb-5" :class="{ 'py-8': isDelegate }" v-show="isDelegate || isVoting">
-      <div class="px-5 sm:px-10" :class="{ 'py-4': !isDelegate }">
+    <section class="page-section mb-5" :class="{ 'py-5 md:py-10': isDelegate }" v-show="isDelegate || isVoting">
+      <div class="px-5 sm:px-10" :class="{ 'py-5': !isDelegate }">
         <delegate :wallet="wallet" v-show="isDelegate" v-on:username="username = $event"></delegate>
         <vote :wallet="wallet" v-show="isVoting"></vote>
         <voters :wallet="wallet" :username="username" v-show="isDelegate"></voters>

--- a/src/pages/Wallet/Blocks.vue
+++ b/src/pages/Wallet/Blocks.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="max-w-2xl mx-auto md:pt-5">
     <content-header>{{ $t("Blocks") }} <span v-show="username">- {{ username }}</span></content-header>
-    <section class="page-section py-10">
+    <section class="page-section py-5 md:py-10">
       <div class="hidden sm:block">
         <table-blocks :blocks="blocks"></table-blocks>
       </div>

--- a/src/pages/Wallet/Transactions.vue
+++ b/src/pages/Wallet/Transactions.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="max-w-2xl mx-auto md:pt-5">
     <content-header>{{ $t("Transactions") }} - {{ $t(capitalize(type)) }}</content-header>
-    <section class="page-section py-10">
+    <section class="page-section py-5 md:py-10">
       <div class="hidden sm:block">
         <table-transactions :transactions="transactions"></table-transactions>
       </div>

--- a/src/pages/Wallet/Voters.vue
+++ b/src/pages/Wallet/Voters.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="max-w-2xl mx-auto md:pt-5">
     <content-header>{{ $t("Voters") }} <span v-show="username">- {{ username }}</span></content-header>
-    <section class="page-section py-10">
+    <section class="page-section py-5 md:py-10">
       <div class="hidden sm:block">
         <table-wallets :wallets="filteredWallets" :total="votes"></table-wallets>
       </div>


### PR DESCRIPTION
Elements with the `page-section` class have different paddings across the page, with styles for smaller displays mostly missing, resulting in an inconsistent look and feel of the site especially on mobile. This PR adds those styles.