### PR TITLE
Removes tooltip warnings in unit tests

### DIFF
--- a/test/unit/setup.js
+++ b/test/unit/setup.js
@@ -1,6 +1,8 @@
 import Vue from 'vue'
 import moment from 'moment-timezone'
+import VTooltip from 'v-tooltip'
 
 Vue.config.productionTip = false
+Vue.use(VTooltip, { defaultHtml: false })
 
 moment.tz.setDefault('America/Los_Angeles')

--- a/test/unit/specs/components/links/Transaction.spec.js
+++ b/test/unit/specs/components/links/Transaction.spec.js
@@ -4,11 +4,9 @@ import store from '@/store'
 
 import Transaction from '@/components/links/Transaction'
 import VueI18n from 'vue-i18n'
-import VTooltip from 'v-tooltip'
 
 const localVue = createLocalVue()
 localVue.use(VueI18n)
-localVue.use(VTooltip, { defaultHtml: false })
 const i18n = new VueI18n({
   locale: 'en',
   fallbackLocale: 'en',

--- a/test/unit/specs/components/wallet/Delegate.spec.js
+++ b/test/unit/specs/components/wallet/Delegate.spec.js
@@ -4,12 +4,10 @@ import mixins from '@/mixins'
 import delegate from '@/components/wallet/Delegate'
 import VueI18n from 'vue-i18n'
 import Vuex from 'vuex'
-import VTooltip from 'v-tooltip'
 
 const localVue = createLocalVue()
 localVue.use(VueI18n)
 localVue.use(Vuex)
-localVue.use(VTooltip, { defaultHtml: false })
 
 const i18n = new VueI18n({
   locale: 'en',


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The unit tests are sometimes hard to debug with the sheer amount of tooltip related warnings showing up. This PR moves the tooltip import to the jest setup.

```
console.error node_modules/vue/dist/vue.runtime.common.js:589
    [Vue warn]: Failed to resolve directive: tooltip
    
    (found in <Anonymous>)
```

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
