### PR TITLE
fix: use total to correctly calculate voter weight on mobile

### DIFF
--- a/src/components/tables/mobile/Wallets.vue
+++ b/src/components/tables/mobile/Wallets.vue
@@ -19,7 +19,7 @@
 
         <div class="list-row">
           <div>{{ $t("Supply") }}</div>
-          <div>{{ readableNumber((row.balance / supply) * 100) }}%</div>
+          <div>{{ readableNumber((row.balance / total) * 100) }}%</div>
         </div>
       </div>
       <div v-if="wallets && !wallets.length" class="px-5 md:px-10">
@@ -37,6 +37,10 @@ export default {
     wallets: {
       // type: Array or null
       required: true,
+    },
+    total: {
+      type: Number,
+      required: true
     },
   },
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
On mobile the "supply" of a voter was based on the total supply of the network, while on desktop it was based on the total amount of votes for a delegate. This PR changes the mobile version to also calculate with the total amount of votes for a delegate to show the same percentage

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
