### PR TITLE
fix: do not wrap "see all" on delegate wallet page

### DIFF
--- a/src/components/wallet/Voters.vue
+++ b/src/components/wallet/Voters.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="list-row-border-t" v-show="Object.keys(voters).length">
     <div>{{ $t("Voters") }}</div>
-    <div>
+    <div class="whitespace-no-wrap">
       <span v-tooltip="{ content: $t('Only voters with more than 0.1 Ark'), placement: 'left' }" :class="voters.length ? 'mr-2' : ''">{{ voters.length }}</span>
       <router-link v-if="wallet.address && voters.length" :to="{ name: 'wallet-voters', params: { address: wallet.address, username: username, page: 1 } }">{{ $t("See all") }}</router-link>
     </div>


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
For some reason the "see all" was wrapped when a delegate would have 40 voters (haven't been able to reproduce it with other numbers, including 3+ digit ones), as shown below:

![see-all-wrap](https://user-images.githubusercontent.com/35610748/45375161-771f7c80-b5f4-11e8-84e9-4e0bab1e71b6.png)

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
