### PR TITLE
Fix/tooltip currency

### DIFF
--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -129,6 +129,7 @@ const methods = {
         maximumFractionDigits: 8,
       })
       : value.toLocaleString(locale, {
+        minimumFractionDigits: 2,
         maximumFractionDigits: 2,
       })
   },

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -129,8 +129,8 @@ const methods = {
         maximumFractionDigits: 8,
       })
       : value.toLocaleString(locale, {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
+        style: 'currency',
+        currency: currencyName
       })
   },
 

--- a/src/pages/Transaction.vue
+++ b/src/pages/Transaction.vue
@@ -44,7 +44,7 @@
 
         <div class="list-row-border-b">
           <div>{{ $t("Amount") }}</div>
-          <div v-if="average" v-tooltip="{ content: `${readableCurrency(transaction.amount, average)} ${currencySymbol}`, placement: 'left' }">{{ readableCrypto(transaction.amount) }}</div>
+          <div v-if="average" v-tooltip="{ content: `${readableCurrency(transaction.amount, average)}`, placement: 'left' }">{{ readableCrypto(transaction.amount) }}</div>
           <div v-else>{{ readableCrypto(transaction.amount) }}</div>
         </div>
 

--- a/src/services/crypto-compare.js
+++ b/src/services/crypto-compare.js
@@ -94,7 +94,7 @@ class CryptoCompareService {
         }
       })
 
-    if (response.data.Response === "Error") {
+    if (response.data.Response === 'Error') {
       return null
     }
 

--- a/test/unit/specs/mixins/readable-currency.spec.js
+++ b/test/unit/specs/mixins/readable-currency.spec.js
@@ -1,10 +1,24 @@
 import mixins from '@/mixins'
 
+const displayCurrency = function(value) {
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  })
+}
+
 describe('readable currency mixin', () => {
   it('should properly format the given data', () => {
-    expect(mixins.readableCurrency(100000000)).toEqual('1')
-    expect(mixins.readableCurrency(1000000000)).toEqual('10')
-    expect(mixins.readableCurrency(10000000000)).toEqual('100')
-    expect(mixins.readableCurrency(100000000000)).toEqual(Number(1000).toLocaleString())
+    expect(mixins.readableCurrency(100000000, null, 'BTC')).toEqual('1')
+    expect(mixins.readableCurrency(1000000000, null, 'BTC')).toEqual('10')
+    expect(mixins.readableCurrency(10000000000, null, 'BTC')).toEqual('100')
+    expect(mixins.readableCurrency(100000000000, null, 'BTC')).toEqual(Number(1000).toLocaleString())
+  })
+
+  it('should format currency with 2 decimals', () => {
+    expect(mixins.readableCurrency(10, 1, 'eur', false)).toEqual(displayCurrency(10))
+    expect(mixins.readableCurrency(10.3, 1, 'eur', false)).toEqual(displayCurrency(10.30))
+    expect(mixins.readableCurrency(10.34, 1, 'eur', false)).toEqual(displayCurrency(10.34))
+    expect(mixins.readableCurrency(10.349, 1, 'eur', false)).toEqual(displayCurrency(10.35))
   })
 })

--- a/test/unit/specs/mixins/readable-currency.spec.js
+++ b/test/unit/specs/mixins/readable-currency.spec.js
@@ -1,9 +1,9 @@
 import mixins from '@/mixins'
 
 const displayCurrency = function(value) {
-  return value.toLocaleString(undefined, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2
+  return value.toLocaleString('en', {
+    style: 'currency',
+    currency: 'eur'
   })
 }
 


### PR DESCRIPTION
## Proposed changes

Initially wanted to change the currency that is shown in the tooltip to always be 2 decimals, but I then saw that the currency sign came after the number (which is not how we usually show currency in my country). Therefore I removed the sign and let the currency be handled by `toLocaleString` instead so it will be correctly shown for everyone.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
