### PR TITLE
fix: auto update currency calculation for tooltip when switching currency

### DIFF
--- a/src/pages/Transaction.vue
+++ b/src/pages/Transaction.vue
@@ -89,6 +89,10 @@ export default {
     ...mapGetters('currency', { currencySymbol: 'symbol' })
   },
 
+  async mounted() {
+    await this.prepareComponent()
+  },
+
   async beforeRouteEnter(to, from, next) {
     try {
       const transaction = await TransactionService.find(to.params.id)
@@ -113,6 +117,13 @@ export default {
   },
 
   methods: {
+    async prepareComponent() {
+      this.$store.watch(state => state.currency.name, value => this.updateAverage())
+    },
+    async updateAverage() {
+      const average = await CryptoCompareService.dailyAverage(this.transaction.timestamp)
+      this.setAverage(average)
+    },
     setTransaction(transaction) {
       this.transaction = transaction
     },

--- a/src/services/crypto-compare.js
+++ b/src/services/crypto-compare.js
@@ -94,7 +94,7 @@ class CryptoCompareService {
         }
       })
 
-    if (response.data.Response === "Error") {
+    if (response.data.Response === 'Error') {
       return null
     }
 


### PR DESCRIPTION


## Proposed changes

When you switch currency, the tooltip will show the new currency sign, but also show the value of the old currency (so 10.34$ will become 10.34€) instead of recalculating it in the new currency. This PR adds a watcher so the value will be recalculated on change.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes

<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
