### PR TITLE
fix: double currency symbol in currency component

### DIFF
--- a/src/components/utils/Currency.vue
+++ b/src/components/utils/Currency.vue
@@ -1,6 +1,6 @@
 <template>
   <span class="whitespace-no-wrap">
-    {{ readableCurrency(amount) }} {{ currencySymbol }}
+    {{ readableCurrency(amount) }}
   </span>
 </template>
 

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -122,12 +122,19 @@ const methods = {
       value /= Math.pow(10, 8)
     }
 
+    const cryptos = {
+      'ARK': 'Ѧ',
+      'BTC': 'Ƀ',
+      'ETH': 'Ξ',
+      'LTC': 'Ł'
+    }
+
     return [store.getters['network/token'], 'BTC', 'ETH', 'LTC'].some(
       c => currencyName.indexOf(c) > -1
     )
-      ? value.toLocaleString(locale, {
-        maximumFractionDigits: 8,
-      })
+      ? `${value.toLocaleString(locale, {
+        maximumFractionDigits: 8
+      })} ${cryptos[currencyName]}`
       : value.toLocaleString(locale, {
         style: 'currency',
         currency: currencyName

--- a/test/unit/specs/components/utils/Currency.spec.js
+++ b/test/unit/specs/components/utils/Currency.spec.js
@@ -18,6 +18,8 @@ const i18n = new VueI18n({
 
 describe('Utils/Currency', () => {
   it('Should display a currency amount', () => {
+    store.dispatch('network/setToken', 'ARK')
+
     const wrapper = mount(Currency, {
       propsData: {
         amount: 1012345678
@@ -29,6 +31,6 @@ describe('Utils/Currency', () => {
     })
     expect(wrapper.contains('span')).toBe(true)
     expect(wrapper.findAll('span')).toHaveLength(1)
-    expect(wrapper.text()).toEqual(mixins.readableCurrency(1012345678) + ' Ѧ')
+    expect(wrapper.text()).toEqual(mixins.readableCurrency(1012345678))
   })
 })

--- a/test/unit/specs/mixins/readable-currency.spec.js
+++ b/test/unit/specs/mixins/readable-currency.spec.js
@@ -1,4 +1,5 @@
 import mixins from '@/mixins'
+import store from '@/store'
 
 const displayCurrency = function(value) {
   return value.toLocaleString('en', {
@@ -8,11 +9,13 @@ const displayCurrency = function(value) {
 }
 
 describe('readable currency mixin', () => {
+  store.dispatch('network/setToken', 'ARK')
+
   it('should properly format the given data', () => {
-    expect(mixins.readableCurrency(100000000, null, 'BTC')).toEqual('1')
-    expect(mixins.readableCurrency(1000000000, null, 'BTC')).toEqual('10')
-    expect(mixins.readableCurrency(10000000000, null, 'BTC')).toEqual('100')
-    expect(mixins.readableCurrency(100000000000, null, 'BTC')).toEqual(Number(1000).toLocaleString())
+    expect(mixins.readableCurrency(100000000, null, 'ARK')).toEqual('1 Ѧ')
+    expect(mixins.readableCurrency(1000000000, null, 'BTC')).toEqual('10 Ƀ')
+    expect(mixins.readableCurrency(10000000000, null, 'ETH')).toEqual('100 Ξ')
+    expect(mixins.readableCurrency(100000000000, null, 'LTC')).toEqual(`${Number(1000).toLocaleString()} Ł`)
   })
 
   it('should format currency with 2 decimals', () => {


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
#373 adds the currency symbol to the readableCurrency function, it was however not removed from the Currency component, resulting in the symbol being shown twice.

![image](https://user-images.githubusercontent.com/6547002/45983085-7dcddb00-c05b-11e8-961b-d90ecfe760a8.png)

Since there is no support for crypto currencies in `toLocaleString`, the respective token symbol is appended after the value, as is done for any amount in ARK.

![image](https://user-images.githubusercontent.com/6547002/45984817-4cf1a400-c063-11e8-96e2-f1e66f241669.png)

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [x] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

Integration tests will most likely fail at the current state of the network, as they depend on blocks not getting missed.