### PR TITLE
feat: add link to delegate wallet in vote / unvote transaction

### DIFF
--- a/src/components/links/Wallet.vue
+++ b/src/components/links/Wallet.vue
@@ -10,10 +10,9 @@
 
       <span v-if="type === 1">{{ $t("2nd Signature Registration") }}</span>
       <span v-else-if="type === 2">{{ $t("Delegate Registration") }}</span>
-      <span v-else-if="type === 3" :class="getVoteColor">
-        {{ isUnvote ? $t("Unvote") : $t("Vote") }}
+      <span v-else-if="type === 3">
         <router-link v-if="votedDelegateAddress" :to="{ name: 'wallet', params: { address: votedDelegateAddress } }">
-          ({{ votedDelegateUsername }})
+          <span :class="getVoteColor">{{ isUnvote ? $t("Unvote") : $t("Vote") }} <span class="italic">({{ votedDelegateUsername }})</span></span>
         </router-link>
       </span>
       <span v-else-if="type === 4">{{ $t("Multisignature Registration") }}</span>
@@ -32,10 +31,9 @@
 
       <span v-if="type === 1">{{ $t("2nd Signature Registration") }}</span>
       <span v-else-if="type === 2">{{ $t("Delegate Registration") }}</span>
-      <span v-else-if="type === 3" :class="getVoteColor">
-        {{ isUnvote ? $t("Unvote") : $t("Vote") }}
+      <span v-else-if="type === 3"> 
         <router-link v-if="votedDelegateAddress" :to="{ name: 'wallet', params: { address: votedDelegateAddress } }">
-          ({{ votedDelegateUsername }})
+          <span :class="getVoteColor">{{ isUnvote ? $t("Unvote") : $t("Vote") }} <span class="italic">({{ votedDelegateUsername }})</span></span>
         </router-link>
       </span>
       <span v-else-if="type === 4">{{ $t("Multisignature Registration") }}</span>

--- a/src/components/links/Wallet.vue
+++ b/src/components/links/Wallet.vue
@@ -10,7 +10,12 @@
 
       <span v-if="type === 1">{{ $t("2nd Signature Registration") }}</span>
       <span v-else-if="type === 2">{{ $t("Delegate Registration") }}</span>
-      <span v-else-if="type === 3" :class="getVoteColor">{{ isUnvote ? $t("Unvote") : $t("Vote") }} ({{ getDelegateUsername() }})</span>
+      <span v-else-if="type === 3" :class="getVoteColor">
+        {{ isUnvote ? $t("Unvote") : $t("Vote") }}
+        <router-link v-if="votedDelegateAddress" :to="{ name: 'wallet', params: { address: votedDelegateAddress } }">
+          ({{ votedDelegateUsername }})
+        </router-link>
+      </span>
       <span v-else-if="type === 4">{{ $t("Multisignature Registration") }}</span>
       <span v-else-if="type === 5">{{ $t("IPFS") }}</span>
       <span v-else-if="type === 6">{{ $t("Timelock Transfer") }}</span>
@@ -27,7 +32,12 @@
 
       <span v-if="type === 1">{{ $t("2nd Signature Registration") }}</span>
       <span v-else-if="type === 2">{{ $t("Delegate Registration") }}</span>
-      <span v-else-if="type === 3" :class="getVoteColor">{{ isUnvote ? $t("Unvote") : $t("Vote") }} ({{ getDelegateUsername() }})</span>
+      <span v-else-if="type === 3" :class="getVoteColor">
+        {{ isUnvote ? $t("Unvote") : $t("Vote") }}
+        <router-link v-if="votedDelegateAddress" :to="{ name: 'wallet', params: { address: votedDelegateAddress } }">
+          ({{ votedDelegateUsername }})
+        </router-link>
+      </span>
       <span v-else-if="type === 4">{{ $t("Multisignature Registration") }}</span>
       <span v-else-if="type === 5">{{ $t("IPFS") }}</span>
       <span v-else-if="type === 6">{{ $t("Timelock Transfer") }}</span>
@@ -61,7 +71,10 @@ export default {
     }
   },
 
-  data: () => ({ delegate: null }),
+  data: () => ({
+    delegate: null,
+    votedDelegate: null
+  }),
 
   mounted() {
     this.determine()
@@ -100,7 +113,7 @@ export default {
     },
 
     isUnvote() {
-      if (this.asset) {
+      if (this.asset && this.asset.votes) {
         const vote = this.asset.votes[0]
         return vote.charAt(0) === '-'
       }
@@ -108,17 +121,32 @@ export default {
     },
 
     votePublicKey() {
-      if (this.asset) {
+      if (this.asset && this.asset.votes) {
         const vote = this.asset.votes[0]
         return vote.substr(1)
       }
       return ''
     },
+
+    votedDelegateAddress() {
+      return this.votedDelegate ? this.votedDelegate.address : ''
+    },
+
+    votedDelegateUsername() {
+      return this.votedDelegate ? this.votedDelegate.username : ''
+    }
   },
 
   methods: {
     determine() {
       this.address ? this.findByAddress() : this.findByPublicKey()
+      if (this.votePublicKey) {
+        this.determineVote()
+      }
+    },
+
+    determineVote() {
+      this.votedDelegate = this.delegates.find(d => d.publicKey === this.votePublicKey)
     },
 
     findByAddress() {
@@ -127,11 +155,6 @@ export default {
 
     findByPublicKey() {
       this.delegate = this.delegates.find(d => d.publicKey === this.publicKey)
-    },
-
-    getDelegateUsername() {
-      const del = this.delegates.find(d => d.publicKey === this.votePublicKey)
-      return del ? del.username : ''
     },
 
     getAddress() {


### PR DESCRIPTION
## Proposed changes

Makes it possible to click on the delegate in the vote / unvote transaction to go to the corresponding wallet:

![votes](https://user-images.githubusercontent.com/35610748/46244965-1f03bb00-c3e7-11e8-978b-d2478df42754.png)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
