### PR TITLE
fix: change number of confirmations shown to 51

### DIFF
--- a/src/components/tables/TransactionsDetail.vue
+++ b/src/components/tables/TransactionsDetail.vue
@@ -42,7 +42,7 @@
       <table-column show="confirmations" :label="$t('Confirmations')" header-class="right-header-end-cell" cell-class="right-end-cell">
         <template slot-scope="row">
           <div class="flex items-center justify-end whitespace-no-wrap">
-            <div v-if="row.confirmations <= 52" class="flex items-center justify-end whitespace-no-wrap">
+            <div v-if="row.confirmations <= 51" class="flex items-center justify-end whitespace-no-wrap">
               <span class="text-green inline-block mr-2">{{ row.confirmations }}</span>
               <img class="icon flex-none" src="@/assets/images/icons/clock.svg" />
             </div>

--- a/src/components/tables/mobile/TransactionsDetail.vue
+++ b/src/components/tables/mobile/TransactionsDetail.vue
@@ -43,7 +43,7 @@
           <div>{{ $t("Confirmations") }}</div>
           <div>
             <div class="flex items-center justify-end">
-              <div v-if="transaction.confirmations <= 52" class="flex items-center justify-end whitespace-no-wrap">
+              <div v-if="transaction.confirmations <= 51" class="flex items-center justify-end whitespace-no-wrap">
                 <span class="text-green inline-block mr-2">{{ transaction.confirmations }}</span>
                 <img class="icon flex-none" src="@/assets/images/icons/clock.svg" />
               </div>


### PR DESCRIPTION
## Proposed changes

Changes the number of confirmations before "Well confirmed" is shown from 52 to 51

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
