### PR TITLE
refactor: show correct address for different transaction types

### DIFF
--- a/src/components/links/Wallet.vue
+++ b/src/components/links/Wallet.vue
@@ -1,7 +1,7 @@
 <template>
   <span>
-    <span v-tooltip="getAddress()" class="hidden md:inline-block">
-      <router-link v-if="!type" :to="{ name: 'wallet', params: { address: walletAddress } }">
+    <span class="hidden md:inline-block">
+      <router-link v-if="!type" v-tooltip="getAddress()" :to="{ name: 'wallet', params: { address: walletAddress } }">
         <span v-if="isKnown">{{ knownWallets[address] }}</span>
         <span v-else-if="delegate">{{ delegate.username }}</span>
         <span v-else-if="hasDefaultSlot"><slot></slot></span>
@@ -11,7 +11,7 @@
       <span v-if="type === 1">{{ $t("2nd Signature Registration") }}</span>
       <span v-else-if="type === 2">{{ $t("Delegate Registration") }}</span>
       <span v-else-if="type === 3">
-        <router-link v-if="votedDelegateAddress" :to="{ name: 'wallet', params: { address: votedDelegateAddress } }">
+        <router-link v-if="votedDelegateAddress" v-tooltip="votedDelegateAddress" :to="{ name: 'wallet', params: { address: votedDelegateAddress } }">
           <span :class="getVoteColor">{{ isUnvote ? $t("Unvote") : $t("Vote") }} <span class="italic">({{ votedDelegateUsername }})</span></span>
         </router-link>
       </span>
@@ -22,8 +22,8 @@
       <span v-else-if="type === 8">{{ $t("Delegate Resignation") }}</span>
     </span>
 
-    <span v-tooltip="walletAddress" class="md:hidden">
-      <router-link v-if="!type" :to="{ name: 'wallet', params: { address: walletAddress } }">
+    <span class="md:hidden">
+      <router-link v-if="!type"v-tooltip="walletAddress"  :to="{ name: 'wallet', params: { address: walletAddress } }">
         <span v-if="isKnown">{{ knownWallets[address] }}</span>
         <span v-else-if="delegate">{{ delegate.username }}</span>
         <span v-else-if="address">{{ truncate(address) }}</span>
@@ -32,7 +32,7 @@
       <span v-if="type === 1">{{ $t("2nd Signature Registration") }}</span>
       <span v-else-if="type === 2">{{ $t("Delegate Registration") }}</span>
       <span v-else-if="type === 3"> 
-        <router-link v-if="votedDelegateAddress" :to="{ name: 'wallet', params: { address: votedDelegateAddress } }">
+        <router-link v-if="votedDelegateAddress" v-tooltip="votedDelegateAddress" :to="{ name: 'wallet', params: { address: votedDelegateAddress } }">
           <span :class="getVoteColor">{{ isUnvote ? $t("Unvote") : $t("Vote") }} <span class="italic">({{ votedDelegateUsername }})</span></span>
         </router-link>
       </span>


### PR DESCRIPTION
## Proposed changes

Transactions would show the sender address in the tooltip of the recipient if transaction type was 3 (vote). So this PR removes the tooltip from the parent span and puts it on the corresponding router-link instead. That way we still have the recipient address when a transaction was send to another address, but we can also show the address of the delegate for which was voted in a vote transaction.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
