### PR TITLE
feat: make delegate search case insensitive

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -35,7 +35,7 @@ export default {
     if (network.alias === 'Development') {
       this.$store.dispatch('ui/setNightMode', true)
     }
-    
+
     this.$store.dispatch('network/setDefaults', network)
 
     this.$store.dispatch('network/setServer', network.server)

--- a/src/components/header/Search.vue
+++ b/src/components/header/Search.vue
@@ -35,6 +35,7 @@ export default {
   }),
 
   computed: {
+    ...mapGetters('delegates', ['delegates']),
     ...mapGetters('ui', ['nightMode']),
     ...mapGetters('network', ['knownWallets'])
   },
@@ -59,6 +60,9 @@ export default {
         const responseAddress = await SearchService.findByAddress(this.query)
         this.changePage('wallet', { address: responseAddress.account.address })
       } catch(e) { this.updateSearchCount(e) }
+
+      const del = this.delegates.find(d => d.username === this.query.toLowerCase())
+      del ? this.changePage('wallet', {  address: del.address }) : this.updateSearchCount({ message: 'No delegate with that username could be found'});
 
       try {
         const responseUsername = await SearchService.findByUsername(this.query)

--- a/src/components/header/Search.vue
+++ b/src/components/header/Search.vue
@@ -62,7 +62,7 @@ export default {
       } catch(e) { this.updateSearchCount(e) }
 
       const del = this.delegates.find(d => d.username === this.query.toLowerCase())
-      del ? this.changePage('wallet', {  address: del.address }) : this.updateSearchCount({ message: 'No delegate with that username could be found'});
+      del ? this.changePage('wallet', { address: del.address }) : this.updateSearchCount({ message: 'No delegate with that username could be found' });
 
       try {
         const responseUsername = await SearchService.findByUsername(this.query)

--- a/test/e2e/specs/homepage.js
+++ b/test/e2e/specs/homepage.js
@@ -232,6 +232,24 @@ module.exports = {
       .assert.urlContains('/wallets/AeLpRK8rFVtBeyBVqBtdQpWDfLzaiNujKr')
   },
 
+  'it should be possible to search for a delegate with uppercase letters': function (browser) {
+    const devServer = browser.globals.devServerURL
+
+    browser
+      .url(devServer)
+      .useCss()
+      .waitForElementVisible('input#search')
+    browser
+      .click('input#search')
+      .waitForElementVisible('input.search-input')
+      .setValue('input.search-input', ['gEnESis_1', browser.Keys.ENTER])
+      .pause(1000)
+    browser
+      .useXpath()
+      .waitForElementVisible("//h1[text() = 'Wallet Summary']")
+      .assert.urlContains('/wallets/AeLpRK8rFVtBeyBVqBtdQpWDfLzaiNujKr')
+  },
+
   'it should be possible to search for an address': function (browser) {
     const devServer = browser.globals.devServerURL
 


### PR DESCRIPTION
## Proposed changes

Makes delegate search case-insensitive. Resolves #244 

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
