### PR TITLE
fix/refactor: shows initial value of zero for the delegate count

### DIFF
--- a/src/components/monitor/DelegateCount.vue
+++ b/src/components/monitor/DelegateCount.vue
@@ -12,6 +12,11 @@
 
 <script type="text/ecmascript-6">
 export default {
-  props: ['delegateCount']
+  props: {
+    delegateCount: {
+      type: Number,
+      required: true
+    }
+  }
 }
 </script>

--- a/src/components/monitor/Details.vue
+++ b/src/components/monitor/Details.vue
@@ -18,6 +18,11 @@ import TotalForged from '@/components/monitor/TotalForged'
 export default {
   components: { DelegateCount, LastBlock, TotalForged },
 
-  props: ['delegateCount']
+  props: {
+    delegateCount: {
+      type: Number,
+      required: true
+    }
+  }
 }
 </script>

--- a/src/pages/DelegateMonitor.vue
+++ b/src/pages/DelegateMonitor.vue
@@ -44,7 +44,7 @@ export default {
 
   data: () => ({
     delegates: null,
-    delegateCount: null,
+    delegateCount: 0,
     activeTab: 'active'
   }),
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The delegate monitor has no initial value for the delegate count, resulting in the span of jumping in position:

![delegates](https://user-images.githubusercontent.com/6547002/46356648-73b36a00-c663-11e8-84f6-f9f6d51007ae.gif)

By adding an initial value, this jump is prevented:

![delegates_fixed](https://user-images.githubusercontent.com/6547002/46356651-757d2d80-c663-11e8-9065-d24e838e815c.gif)

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
