### PR TITLE
fix: sets tooltip color and better text if forgingStatus is 5

### DIFF
--- a/src/components/monitor/ActiveDelegates.vue
+++ b/src/components/monitor/ActiveDelegates.vue
@@ -88,17 +88,18 @@ export default {
         '2': this.$i18n.t('Not Forging'),
         '3': this.$i18n.t('Awaiting Slot'),
         '4': this.$i18n.t('Missed block, Awaiting Slot'),
-        '5': this.$i18n.t('Not Forging'),
+        '5': this.$i18n.t('Never Forged'),
       }[row.forgingStatus.code]
 
       const lastBlock = row.forgingStatus.lastBlock
 
-      return lastBlock ? {
-        content: `[${status}] Last Block @ ${
+      return {
+        content: lastBlock ? `[${status}] Last Block @ ${
             lastBlock.height
-          } on ${this.readableTimestamp(lastBlock.timestamp)}`,
+          } on ${this.readableTimestamp(lastBlock.timestamp)}`
+          : status,
         classes: [`tooltip-bg-${row.forgingStatus.code}`, 'font-sans']
-      } : status
+      }
     },
 
     statusColor(row) {
@@ -108,7 +109,7 @@ export default {
         '2': '#ef192d', // Not Forging
         '3': '#838a9b', // Awaiting Slot
         '4': '#f6993f', // Missed in previous round, now awaiting Slot
-        '5': '#ef192d', // Not Forging
+        '5': '#ef192d', // Never forged
       }[row.forgingStatus.code]
     }
   },

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -58,6 +58,7 @@
   "Forged block recently": "Forged block recently",
   "Missed block": "Missed block",
   "Not forging": "Not forging",
+  "Never forged": "Never forged",
   "In queue for forging": "In queue for forging",
   "Last block": "Last block",
   "from transactions": "from 0 transactions | from 1 transaction | from {count} transactions",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -57,6 +57,7 @@
   "Forged block recently": "Recentelijk block geforged",
   "Missed block": "Block gemist",
   "Not forging": "Niet aan het forgen",
+  "Never forged": "Nooit geforged",
   "In queue for forging": "In de rij om te forgen",
   "Last block": "Laatste block",
   "from transactions": "van 0 transacties | van 1 transactie | van {count} transacties",

--- a/src/styles/tooltips.css
+++ b/src/styles/tooltips.css
@@ -154,7 +154,7 @@
   border-color: #f6993f;
 }
 
-/* Not Forging */
+/* Never forged */
 .tooltip.tooltip-bg-5 .tooltip-inner {
   background-color: #ef192d;
   color: white;


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

`forgingStatus` 5 represents the fact that a delegate has never forged. This PR changes the tooltip text to `Never forged` and sets the background color to red, like when a delegate is `Not forging`.

![image](https://user-images.githubusercontent.com/6547002/46365801-d3b50b00-c679-11e8-951f-561bc25bf659.png)

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
