### PR TITLE
fix: don't show additional arktoshis in supply

### DIFF
--- a/src/components/ContentHeader.vue
+++ b/src/components/ContentHeader.vue
@@ -20,7 +20,7 @@
       </div>
       <div>
         <span>{{ $t("Supply") }}:</span>
-        <span class="block md:inline-block whitespace-no-wrap">{{ readableCrypto(supply) }}</span>
+        <span class="block md:inline-block whitespace-no-wrap">{{ readableCrypto(supply, true, 0) }}</span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Proposed changes

Don't show the mysterious 4 arktoshis from the genesis block
Will test it after I got some sleep

## Types of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes

<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
