### PR TITLE
fix: use network token in voter count tooltip

### DIFF
--- a/src/components/wallet/Voters.vue
+++ b/src/components/wallet/Voters.vue
@@ -2,7 +2,7 @@
   <div class="list-row-border-t" v-show="Object.keys(voters).length">
     <div>{{ $t("Voters") }}</div>
     <div class="whitespace-no-wrap">
-      <span v-tooltip="{ content: $t('Only voters with more than 0.1 Ark'), placement: 'left' }" :class="voters.length ? 'mr-2' : ''">{{ voters.length }}</span>
+      <span v-tooltip="{ content: $t('Only voters with more than 0.1 token', { token: networkToken() }), placement: 'left' }" :class="voters.length ? 'mr-2' : ''">{{ voters.length }}</span>
       <router-link v-if="wallet.address && voters.length" :to="{ name: 'wallet-voters', params: { address: wallet.address, username: username, page: 1 } }">{{ $t("See all") }}</router-link>
     </div>
   </div>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -83,7 +83,7 @@
   "missed": "missed",
   "Votes": "Votes",
   "Voters": "Voters",
-  "Only voters with more than 0.1 Ark": "Only voters with more than 0.1 Ark",
+  "Only voters with more than 0.1 token": "Only voters with more than 0.1 {token}",
   "See all": "See all",
   "All": "All",
   "Sent": "Sent",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -82,7 +82,7 @@
   "missed": "gemist",
   "Votes": "Stemmen",
   "Voters": "Stemmers",
-  "Only voters with more than 0.1 Ark": "Alleen stemmers met meer dan 0.1 Ark",
+  "Only voters with more than 0.1 token": "Alleen stemmers met meer dan 0.1 {token}",
   "See all": "Zie alle",
   "All": "Alles",
   "Sent": "Verzonden",

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -81,7 +81,7 @@
   "missed": "perdido",
   "Votes": "Votos",
   "Voters": "Votantes",
-  "Only voters with more than 0.1 Ark": "Somente votantes com mais de 0.1 Ark",
+  "Only voters with more than 0.1 token": "Somente votantes com mais de 0.1 {token}",
   "See all": "Ver todos",
   "All": "Todos",
   "Sent": "Enviado",


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The voter count tooltip currently shows `[...] 0.1 Ark`, independent of the current network. This PR changes the tooltip to make use of the stored network token thus making it network agnostic; on devnet it displays `[...] 0.1 DARK` for instance.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes