### PR TITLE
fix: add error handling around WalletService.vote()

### DIFF
--- a/src/components/wallet/Vote.vue
+++ b/src/components/wallet/Vote.vue
@@ -32,8 +32,13 @@ export default {
 
   methods: {
     async getVotes() {
-      const response = await WalletService.vote(this.wallet.address)
-      this.delegate = response
+      try {
+        const response = await WalletService.vote(this.wallet.address)
+        this.delegate = response
+      } catch(e) {
+        console.log(e.message || e.data.error)
+        this.delegate = {}
+      }
     }
   }
 }

--- a/src/pages/Wallet.vue
+++ b/src/pages/Wallet.vue
@@ -67,8 +67,13 @@ export default {
     async setWallet(wallet) {
       this.wallet = wallet
 
-      const vote = await WalletService.vote(wallet.address)
-      this.isVoting = vote ? true : false
+      try {
+        const vote = await WalletService.vote(wallet.address)
+        this.isVoting = vote
+      } catch(e) {
+        console.log(e.message || e.data.error)
+        this.isVoting = false
+      }
     },
   },
 }

--- a/test/unit/specs/services/search.spec.js
+++ b/test/unit/specs/services/search.spec.js
@@ -4,7 +4,7 @@ import store from '@/store'
 describe('Search Service', () => {
   beforeAll(() => {
     jest.setTimeout(60000)
-    
+
     store.dispatch('network/setServer', 'https://explorer.ark.io:8443/api')
   })
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

As noted by delegate fun:

> If you search for a delegate who is voting for another delegate, then look up a delegate that isn't voting for anyone, the latter delegate is shown to be voting for the first delegate you searched for. Example: Look up `arkmoon` on devnet explorer - there's no "Votes" row in the table as the delegate isn't voting for anyone. Then search for `boldninja` (who is voting for himself), then look up `arkmoon` again - for me it then shows that `arkmoon` is voting for `boldninja` even though it's not correct.

This PR adds proper error handling around the usage of `WalletService.vote()` so that the above written cannot happen.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
