### PR TITLE
fix: remove double nightMode dispatch

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -32,9 +32,6 @@ export default {
 
   async created() {
     const network = require(`../networks/${process.env.EXPLORER_CONFIG}`)
-    if (network.alias === 'Development') {
-      this.$store.dispatch('ui/setNightMode', true)
-    }
 
     this.$store.dispatch('network/setDefaults', network)
 
@@ -79,7 +76,7 @@ export default {
 
     this.$store.dispatch(
       'ui/setNightMode',
-      localStorage.getItem('nightMode') || false
+      localStorage.getItem('nightMode') || (network.alias === 'Development') ? true : false
     )
 
     this.updateCurrencyRate()


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Issue notable only on devnet:

There are currently two store dispatches of the `nightMode` value in `App.vue`. This results in the stored value in `localStorage` to be overwritten every time with `true` - which is not necessarily the value one would want.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
