### PR TITLE
feat: add dark-themed tooltips

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -28,7 +28,10 @@ new Vue({
   template: '<App/>',
 })
 
-Vue.use(VTooltip, { defaultHtml: false })
+Vue.use(VTooltip, {
+	defaultHtml: false,
+	defaultContainer: 'main'
+})
 
 /** Sortable Tables */
 TableComponent.settings({

--- a/src/styles/tooltips.css
+++ b/src/styles/tooltips.css
@@ -20,6 +20,15 @@
   z-index: 1;
 }
 
+.theme-dark .tooltip .tooltip-inner {
+  background: #373b4a;
+  color: #ffffff;
+}
+
+.theme-dark .tooltip .tooltip-arrow {
+  border-color: #373b4a;
+}
+
 .tooltip[x-placement^='top'] {
   margin-bottom: 5px;
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Adds dark-themed tooltips.

![image](https://user-images.githubusercontent.com/6547002/47364336-552c1600-d6d9-11e8-9e35-b54c809f4d5a.png)

For this to work without any big changes, the default container of the tooltips had to be changed to the `<main>` element.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes