### PR TITLE
refactor: search tooltip arrow placement

### DIFF
--- a/src/components/header/Search.vue
+++ b/src/components/header/Search.vue
@@ -148,5 +148,6 @@ export default {
 
 .tooltip.search-tip .tooltip-arrow {
   border-color: #ef192d;
+  left: 11px !important;
 }
 </style>


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The arrow position from the failed search tooltip is really off.

![image](https://user-images.githubusercontent.com/6547002/47367698-7cd2ac80-d6e0-11e8-8a20-be937951fb76.png)

The only way to change that without changing the rest of the tooltip position was to hardcode the offset from the left.

![image](https://user-images.githubusercontent.com/6547002/47367792-b0153b80-d6e0-11e8-823d-bb9bbaef1a01.png)

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes