### PR TITLE
fix: move search-tip styles to tooltips.css

### DIFF
--- a/src/components/header/Search.vue
+++ b/src/components/header/Search.vue
@@ -140,14 +140,4 @@ export default {
   box-shadow: 0 0 13px 2px rgba(197, 197, 213, 0.24);
   cursor: pointer;
 }
-
-.tooltip.search-tip .tooltip-inner {
-  background-color: #ef192d;
-  color: white;
-}
-
-.tooltip.search-tip .tooltip-arrow {
-  border-color: #ef192d;
-  left: 11px !important;
-}
 </style>

--- a/src/styles/tooltips.css
+++ b/src/styles/tooltips.css
@@ -29,6 +29,16 @@
   border-color: #373b4a;
 }
 
+.tooltip.search-tip .tooltip-inner {
+  background-color: #ef192d;
+  color: white;
+}
+
+.tooltip.search-tip .tooltip-arrow {
+  border-color: #ef192d;
+  left: 11px !important;
+}
+
 .tooltip[x-placement^='top'] {
   margin-bottom: 5px;
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

This PR moves the declaration of the search tooltip styles to `tooltips.css`, so that the applied styles don't get overwritten when night mode is enabled.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes