### PR TITLE
fix: move timeout in recipient test

### DIFF
--- a/test/e2e/specs/transactions.js
+++ b/test/e2e/specs/transactions.js
@@ -108,8 +108,8 @@ module.exports = {
           console.log('Link is present')
           browser
             .waitForElementVisible("//tbody[contains(@class, 'table-component__table__body')]//tr[1]//td[4]//a[1]")
-            .click("//tbody[contains(@class, 'table-component__table__body')]//tr[1]//td[4]//a[1]")
             .pause(500)
+            .click("//tbody[contains(@class, 'table-component__table__body')]//tr[1]//td[4]//a[1]")
           browser
             .useCss()
             .waitForElementVisible('h1')


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

This moves the `pause` in the recipient link from after to before the click event.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Test (adding missing tests or fixing existing tests)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes