### PR TITLE
Fix unknown getter error in unit tests

### DIFF
--- a/test/unit/specs/components/header/ToggleLanguage.spec.js
+++ b/test/unit/specs/components/header/ToggleLanguage.spec.js
@@ -22,9 +22,15 @@ const store = new Vuex.Store({
   modules: {
     ui: {
       namespaced: true,
-      state: { language: 'en' },
+      state: {
+        language: 'en',
+        headerType: null
+      },
       actions: uiAction,
-      getters: { language: state => 'en' }
+      getters: {
+        language: state => 'en',
+        headerType: state => null
+      }
     }
   },
   strict: true


### PR DESCRIPTION
## Proposed changes
I'm patching my own mistake. Due to lack of store getter defined in test some (harmless) errors were reported by test runner.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes

Resolves https://github.com/ArkEcosystem/explorer/issues/428
