### PR TITLE
Adjust close button styles to fit new alignment

### DIFF
--- a/src/components/header/currencies/Desktop.vue
+++ b/src/components/header/currencies/Desktop.vue
@@ -39,6 +39,6 @@ export default {
 
 <style scoped>
   .close-button {
-    margin-right: 0.825rem;
+    margin-left: 0.825rem;
   }
 </style>

--- a/src/components/header/languages/Desktop.vue
+++ b/src/components/header/languages/Desktop.vue
@@ -39,6 +39,6 @@ export default {
 
 <style scoped>
   .close-button {
-    margin-right: 0.825rem;
+    margin-left: 0.825rem;
   }
 </style>


### PR DESCRIPTION
## Proposed changes
This adjusts existing scoped styles for .close-button margins. These margins are there to create more space between items and close button, not close button and box border. This should've been done together with language switcher (when menu alignment got changed) but it got overlooked.
It's very minor so I won't be opening a new issue for this if that's okay.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes