### PR TITLE
 Change static "ARK" to networkToken() in price tabs

### DIFF
--- a/src/components/ContentHeader.vue
+++ b/src/components/ContentHeader.vue
@@ -15,7 +15,7 @@
         <span class="block md:inline-block">{{ height.toLocaleString() }}</span>
       </div>
       <div class="mr-2">
-        <span>{{ networkToken() }}/{{name}}:</span>
+        <span>{{ networkToken() }}/{{ name }}:</span>
         <span class="block md:inline-block">{{ rawCurrency(rate, name) }}</span>
       </div>
       <div>

--- a/src/components/ContentHeader.vue
+++ b/src/components/ContentHeader.vue
@@ -15,7 +15,7 @@
         <span class="block md:inline-block">{{ height.toLocaleString() }}</span>
       </div>
       <div class="mr-2">
-        <span>ARK/{{name}}:</span>
+        <span>{{ networkToken() }}/{{name}}:</span>
         <span class="block md:inline-block">{{ rawCurrency(rate, name) }}</span>
       </div>
       <div>

--- a/src/components/header/ToggleCurrency.vue
+++ b/src/components/header/ToggleCurrency.vue
@@ -4,7 +4,7 @@
     class="px-2 md:px-4 py-3 md:py-6 flex items-center text-sm border-b-2 margin-t-2 border-transparent hover:border-red">
     <img class="md:mr-4 flex-none" :src="imageSource" style="height: 16px;" />
     <span class="whitespace-no-wrap text-theme-text-content hidden md:inline-block">
-      ARK/{{ currencyName }}: {{ rawCurrency(currencyRate, currencyName) }}
+      {{ networkToken() }}/{{ currencyName }}: {{ rawCurrency(currencyRate, currencyName) }}
     </span>
   </button>
 </template>


### PR DESCRIPTION
## Proposed changes

Change static "ARK" to networkToken() in price tabs. Essentially it pulls the token name from the API instead of using static text. This makes it easy to port the explorer to other chains.


## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

N/A
-->
