### PR TITLE
fix: properly terminate browser sessions in e2e tests

### DIFF
--- a/test/e2e/specs/block-detail.js
+++ b/test/e2e/specs/block-detail.js
@@ -83,6 +83,6 @@ module.exports = {
       .click('div.list-row a')
       .useXpath().waitForElementVisible("//h1[text() = 'Wallet Summary']")
       .assert.urlContains('wallets/ALLZ3TQKTaHm2Bte4SrXL9C5cS8ZovqFfZ')
-      .end()
+    browser.end()
   }
 }

--- a/test/e2e/specs/blocks.js
+++ b/test/e2e/specs/blocks.js
@@ -87,6 +87,6 @@ module.exports = {
     browser
       .waitForElementVisible("//h1[text() = 'Wallet Summary']")
       .assert.urlContains('/wallets/')
-      .end()
+    browser.end()
   }
 }

--- a/test/e2e/specs/homepage.js
+++ b/test/e2e/specs/homepage.js
@@ -387,6 +387,6 @@ module.exports = {
     browser
       .useXpath()
       .waitForElementVisible("//div[contains(@class, 'tooltip-inner') and text() = 'Nothing matched your search']")
-      .end()
+    browser.end()
   }
 }

--- a/test/e2e/specs/top-wallets.js
+++ b/test/e2e/specs/top-wallets.js
@@ -79,6 +79,6 @@ module.exports = {
       .useCss()
       .waitForElementVisible('h1')
       .assert.containsText('h1', 'Wallet Summary')
-      .end()
+    browser.end()
   }
 }

--- a/test/e2e/specs/transaction-detail.js
+++ b/test/e2e/specs/transaction-detail.js
@@ -67,6 +67,7 @@ module.exports = {
     browser
       .waitForElementVisible("//h1[text() = 'Block']")
       .assert.urlContains('block/12374209887221238137')
+    browser.end()
   },
 
   // TODO: unsure why this one doesn't work reliably, needs to be looked into further

--- a/test/e2e/specs/transactions.js
+++ b/test/e2e/specs/transactions.js
@@ -116,8 +116,8 @@ module.exports = {
             .waitForElementVisible('h1')
             .assert.containsText('h1', 'Wallet Summary')
             .assert.urlContains('/wallets/')
-            .end()
         }
       })
+    browser.end()
   }
 }

--- a/test/e2e/specs/voters.js
+++ b/test/e2e/specs/voters.js
@@ -92,6 +92,6 @@ module.exports = {
       .waitForElementVisible("//h1[text() = 'Ooops!']")
     browser
       .assert.urlContains('/404')
-      .end()
+    browser.end()
   }
 }

--- a/test/e2e/specs/wallet.js
+++ b/test/e2e/specs/wallet.js
@@ -120,6 +120,6 @@ module.exports = {
       .waitForElementVisible("//h1[text() = 'Ooops!']")
     browser
       .assert.urlContains('/404')
-      .end()
+    browser.end()
   }
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

In some e2e tests the browser session was not being properly terminated.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Test (adding missing tests or fixing existing tests)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
