### PR TITLE
Add missing translation in delegate monitor

### DIFF
--- a/src/components/monitor/ActiveDelegates.vue
+++ b/src/components/monitor/ActiveDelegates.vue
@@ -92,11 +92,10 @@ export default {
       }[row.forgingStatus.code]
 
       const lastBlock = row.forgingStatus.lastBlock
+      const translation = this.$i18n.t('Last block at height on', { height: lastBlock.height })
 
       return {
-        content: lastBlock ? `[${status}] Last Block @ ${
-            lastBlock.height
-          } on ${this.readableTimestamp(lastBlock.timestamp)}`
+        content: lastBlock ? `[${status}] ${translation} ${this.readableTimestamp(lastBlock.timestamp)}`
           : status,
         classes: [`tooltip-bg-${row.forgingStatus.code}`, 'font-sans']
       }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -69,6 +69,7 @@
   "Not Forging": "Not Forging",
   "Awaiting Slot": "Awaiting Slot",
   "Never": "Never",
+  "Last block at height on": "Last Block @ {height} on",
 
   "Address": "Address",
   "Public Key": "Public Key",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -68,6 +68,7 @@
   "Not Forging": "Niet aan het forgen",
   "Awaiting Slot": "Wachten op een plek",
   "Never": "Nooit",
+  "Last block at height on": "Last Block @ {height} on",
 
   "Address": "Adres",
   "Public Key": "Public Key",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -69,6 +69,7 @@
   "Not Forging": "Nie wydobywa",
   "Awaiting Slot": "Oczekuje na miejsce",
   "Never": "Nigdy",
+  "Last block at height on": "Ostatni blok @ {height} wytworzony",
 
   "Address": "Adres",
   "Public Key": "Klucz publiczny",

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -67,6 +67,7 @@
   "Not Forging": "Não está Forjando",
   "Awaiting Slot": "Aguardando Slot",
   "Never": "Nunca",
+  "Last block at height on": "Last Block @ {height} on",
 
   "Address": "Endereço",
   "Public Key": "Public Key",


### PR DESCRIPTION
## Proposed changes
There was a translation missing from tooltip in delegate monitor. Text was always displayed in English (no i18n call).
I've added a call to i18n interface and filled translations for English (same as it was) and Polish as these are the languages I speak. I've also added placeholders in every other translations file in English, so this will remain unchanged. Someone who speaks one of these two languages should translate.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes