### PR TITLE
refactor: change page on first search match

### DIFF
--- a/src/components/header/Search.vue
+++ b/src/components/header/Search.vue
@@ -57,40 +57,51 @@ export default {
       this.searchCount = 0
       this.query = this.query.trim()
 
+      const address = this.findByNameInKnownWallets(this.query)
+      if (address) {
+        this.changePage('wallet', { address: address })
+        return
+      } else {
+        this.updateSearchCount({ message: 'No known wallet with that name could be found' })
+      }
+
+      const del = this.delegates.find(d => d.username === this.query.toLowerCase())
+      if (del) {
+        this.changePage('wallet', { address: del.address })
+        return
+      } else {
+        this.updateSearchCount({ message: 'No delegate with that username could be found' });
+      }
+
       try {
         const responseAddress = await SearchService.findByAddress(this.query)
         this.changePage('wallet', { address: responseAddress.account.address })
+        return
       } catch(e) { this.updateSearchCount(e) }
-
-      const del = this.delegates.find(d => d.username === this.query.toLowerCase())
-      del ? this.changePage('wallet', { address: del.address }) : this.updateSearchCount({ message: 'No delegate with that username could be found' });
 
       try {
         const responseUsername = await SearchService.findByUsername(this.query)
         this.changePage('wallet', { address: responseUsername.delegate.address })
+        return
       } catch(e) { this.updateSearchCount(e) }
 
       try {
         const responsePublicKey = await SearchService.findByPublicKey(this.query)
         this.changePage('wallet', { address: responsePublicKey.delegate.address })
+        return
       } catch(e) { this.updateSearchCount(e) }
 
       try {
         const responseBlock = await SearchService.findByBlockId(this.query)
         this.changePage('block', { id: responseBlock.block.id })
+        return
       } catch(e) { this.updateSearchCount(e) }
 
       try {
         const responseTransaction = await SearchService.findByTransactionId(this.query)
         this.changePage('transaction', { id: responseTransaction.transaction.id })
+        return
       } catch(e) { this.updateSearchCount(e) }
-
-      const address = this.findByNameInKnownWallets(this.query)
-      if (address) {
-        this.changePage('wallet', { address: address })
-      } else {
-        this.updateSearchCount(null)
-      }
     },
 
     updateSearchCount(err) {

--- a/test/unit/specs/services/transaction.spec.js
+++ b/test/unit/specs/services/transaction.spec.js
@@ -60,7 +60,7 @@ describe('Transaction Service', () => {
   it('should return the latest registrations', async () => {
     const data = await transactionService.latestRegistrations()
     expect(data).toHaveLength(5)
-    expect(Object.keys(data[0]).sort()).toEqual(blockPropertyArray.concat(['asset']).sort())
+    expect(Object.keys(data[0]).sort()).toEqual(blockPropertyArray.concat(['asset', 'signSignature']).sort())
     expect(data[0].type).toBe(2)
     expect(data[0].timestamp < data[1].timestamp)
   })


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The Search function currently forces a page change as soon as a match has been found. When multiple matches are found, this causes multiple page changes. This PR changes the order of the queries/lookups and behaviour, so that the page will be based on the first match only.

As an example: searching for 'binance' yields two very visible page changes.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
