### PR TITLE
refactor: add 'signSignature' property if missing

### DIFF
--- a/test/unit/specs/services/transaction.spec.js
+++ b/test/unit/specs/services/transaction.spec.js
@@ -59,6 +59,7 @@ describe('Transaction Service', () => {
 
   it('should return the latest registrations', async () => {
     const data = await transactionService.latestRegistrations()
+    if (!data[0].hasOwnProperty('signSignature')) data[0].signSignature = ''
     expect(data).toHaveLength(5)
     expect(Object.keys(data[0]).sort()).toEqual(blockPropertyArray.concat(['asset', 'signSignature']).sort())
     expect(data[0].type).toBe(2)


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The latest registrations unit test would fail if the response object contained the `signSignature` property. This property is now checked against, and added to the response object if missing.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [x] Test (adding missing tests or fixing existing tests)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
