### PR TITLE
refactor: properly initialize and set locale

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -19,6 +19,7 @@ import BlockService from '@/services/block'
 import DelegateService from '@/services/delegate'
 import LoaderService from '@/services/loader'
 import { mapGetters } from 'vuex'
+import moment from 'moment'
 
 import '@/styles/style.css'
 
@@ -80,6 +81,7 @@ export default {
     )
 
     this.updateI18n()
+    this.updateLocale()
     this.updateCurrencyRate()
     this.updateSupply()
     this.updateHeight()
@@ -92,7 +94,7 @@ export default {
 
   computed: {
     ...mapGetters('currency', { currencyName: 'name' }),
-    ...mapGetters('ui', ['language', 'nightMode']),
+    ...mapGetters('ui', ['language', 'locale', 'nightMode']),
     ...mapGetters('network', ['token']),
   },
 
@@ -125,6 +127,10 @@ export default {
 
     updateI18n() {
       this.$i18n.locale = this.language
+    },
+
+    updateLocale() {
+      moment.locale(this.locale)
     },
 
     initialiseTimers() {

--- a/src/components/header/languages/Desktop.vue
+++ b/src/components/header/languages/Desktop.vue
@@ -11,6 +11,8 @@
 </template>
 
 <script type="text/ecmascript-6">
+import moment from 'moment'
+
 export default {
   computed: {
     languages() {
@@ -22,11 +24,20 @@ export default {
     setLanguage(language) {
       this.$store.dispatch('ui/setLanguage', language)
       this.setI18nLanguage(language)
+
+      const locale = language.split('-')[0]
+      this.$store.dispatch('ui/setLocale', locale)
+      this.setLocale(locale)
+
       this.$store.dispatch('ui/setHeaderType', null)
     },
 
     setI18nLanguage(language) {
       this.$i18n.locale = language
+    },
+
+    setLocale(locale) {
+      moment.locale(locale)
     },
 
     getLanguageFlag(language) {

--- a/src/components/header/languages/Mobile.vue
+++ b/src/components/header/languages/Mobile.vue
@@ -12,8 +12,8 @@
 </template>
 
 <script type="text/ecmascript-6">
-
 import { mapGetters } from 'vuex'
+import moment from 'moment'
 
 export default {
   computed: {
@@ -28,11 +28,20 @@ export default {
     setLanguage(language) {
       this.$store.dispatch('ui/setLanguage', language)
       this.setI18nLanguage(language)
+
+      const locale = language.split('-')[0]
+      this.$store.dispatch('ui/setLocale', locale)
+      this.setLocale(locale)
+
       this.$store.dispatch('ui/setHeaderType', null)
     },
 
     setI18nLanguage(language) {
       this.$i18n.locale = language
+    },
+
+    setLocale(locale) {
+      moment.locale(locale)
     },
 
     getLanguageFlag(language) {

--- a/src/components/header/languages/Mobile.vue
+++ b/src/components/header/languages/Mobile.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul class="language-menu menu-container text-center max-w-480px justify-center bg-table-row list-reset absolute pin-b pin-r py-1 px-4 flex items-center block xl:hidden">
+  <ul class="language-menu menu-container text-center max-w-480px justify-center bg-table-row list-reset absolute pin-b pin-r py-1 px-4 items-center hidden md:flex xl:hidden">
     <li v-for="lang in languages"
             @click="setLanguage(lang)"
             :key="lang"

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -2,8 +2,7 @@ import Vue from 'vue'
 import moment from 'moment'
 import store from '@/store'
 
-const locale = localStorage.getItem('locale') || navigator.language || 'en'
-moment.locale(locale)
+const locale = store.getters['ui/locale']
 
 const methods = {
   isDelegateByAddress(address) {

--- a/test/e2e/specs/homepage.js
+++ b/test/e2e/specs/homepage.js
@@ -262,6 +262,8 @@ module.exports = {
 
     browser
       .url(devServer)
+      .useXpath()
+      .waitForElementVisible("//tbody[contains(@class, 'table-component__table__body')]")
       .useCss()
       .waitForElementVisible('input#search')
     browser
@@ -281,6 +283,8 @@ module.exports = {
 
     browser
       .url(devServer)
+      .useXpath()
+      .waitForElementVisible("//tbody[contains(@class, 'table-component__table__body')]")
       .useCss()
       .waitForElementVisible('input#search')
     browser
@@ -300,6 +304,8 @@ module.exports = {
 
     browser
       .url(devServer)
+      .useXpath()
+      .waitForElementVisible("//tbody[contains(@class, 'table-component__table__body')]")
       .useCss()
       .waitForElementVisible('input#search')
     browser
@@ -319,6 +325,8 @@ module.exports = {
 
     browser
       .url(devServer)
+      .useXpath()
+      .waitForElementVisible("//tbody[contains(@class, 'table-component__table__body')]")
       .useCss()
       .waitForElementVisible('input#search')
     browser
@@ -338,6 +346,8 @@ module.exports = {
 
     browser
       .url(devServer)
+      .useXpath()
+      .waitForElementVisible("//tbody[contains(@class, 'table-component__table__body')]")
       .useCss()
       .waitForElementVisible('input#search')
     browser
@@ -357,6 +367,8 @@ module.exports = {
 
     browser
       .url(devServer)
+      .useXpath()
+      .waitForElementVisible("//tbody[contains(@class, 'table-component__table__body')]")
       .useCss()
       .waitForElementVisible('input#search')
     browser
@@ -376,6 +388,8 @@ module.exports = {
 
     browser
       .url(devServer)
+      .useXpath()
+      .waitForElementVisible("//tbody[contains(@class, 'table-component__table__body')]")
       .useCss()
       .waitForElementVisible('input#search')
     browser

--- a/test/unit/specs/components/header/Languages.spec.js
+++ b/test/unit/specs/components/header/Languages.spec.js
@@ -4,6 +4,8 @@ import DesktopLanguage from '@/components/header/languages/Desktop'
 import MobileLanguage from '@/components/header/languages/Mobile'
 import VueI18n from 'vue-i18n'
 import Vuex from 'vuex'
+import moment from 'moment'
+
 const localVue = createLocalVue()
 
 localVue.use(VueI18n)
@@ -38,6 +40,7 @@ const store = new Vuex.Store({
 describe('header/languages/Desktop', () => {
   it('Should change language', () => {
     i18n.locale = 'en'
+    moment.locale('en')
 
     const dispatchMock = jest.fn()
     store.dispatch = dispatchMock
@@ -50,11 +53,13 @@ describe('header/languages/Desktop', () => {
     })
 
     expect(i18n.locale).not.toBe('nl')
+    expect(moment.locale()).not.toBe('nl')
     wrapper.find('.menu-button').trigger('click')
 
-    expect(dispatchMock).toHaveBeenCalledTimes(2)
+    expect(dispatchMock).toHaveBeenCalledTimes(3)
     expect(dispatchMock).toHaveBeenNthCalledWith(1, 'ui/setLanguage', 'nl')
-    expect(dispatchMock).toHaveBeenNthCalledWith(2, 'ui/setHeaderType', null)
+    expect(dispatchMock).toHaveBeenNthCalledWith(2, 'ui/setLocale', 'nl')
+    expect(dispatchMock).toHaveBeenNthCalledWith(3, 'ui/setHeaderType', null)
     expect(i18n.locale).toBe('nl')
   })
 
@@ -78,6 +83,7 @@ describe('header/languages/Desktop', () => {
 describe('header/languages/Mobile', () => {
   it('Should change language', () => {
     i18n.locale = 'en'
+    moment.locale('en')
 
     const dispatchMock = jest.fn()
     store.dispatch = dispatchMock
@@ -90,11 +96,13 @@ describe('header/languages/Mobile', () => {
     })
 
     expect(i18n.locale).not.toBe('nl')
+    expect(moment.locale()).not.toBe('nl')
     wrapper.find('.language-menu > li').trigger('click')
 
-    expect(dispatchMock).toHaveBeenCalledTimes(2)
+    expect(dispatchMock).toHaveBeenCalledTimes(3)
     expect(dispatchMock).toHaveBeenNthCalledWith(1, 'ui/setLanguage', 'nl')
-    expect(dispatchMock).toHaveBeenNthCalledWith(2, 'ui/setHeaderType', null)
+    expect(dispatchMock).toHaveBeenNthCalledWith(2, 'ui/setLocale', 'nl')
+    expect(dispatchMock).toHaveBeenNthCalledWith(3, 'ui/setHeaderType', null)
     expect(i18n.locale).toBe('nl')
   })
 })


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The locale was being set based on the value of `navigator.language`. This PR changes that behaviour to set the locale upon changing language through the language switcher, and also sets the locale used by `momentjs`.

This PR also tries to harden the "uppercase delegate username search"-test, which still fails from time to time.
 
## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
