### PR TITLE
fix: use momentjs local feature to show consistent tx timestamp

### DIFF
--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -32,8 +32,8 @@ const methods = {
         minute: 0,
         second: 0,
       })
-      .add((typeof timeZoneOffset !== 'undefined' ? timeZoneOffset : new Date().getTimezoneOffset()) * (-1), 'minutes')
       .add(value, 'seconds')
+      .local()
       .format('L LTS')
   },
 


### PR DESCRIPTION
## Fix timezone offset bug when viewing a transaction before or after Daylight Savings Time.
When viewing a transaction, the timestamp would change by 1 hour if viewing before or after daylight savings time.
Resolves [ArkEcosystem/explorer/issues/454]

## Types of changes
This simply uses MomentJS's .local() function to calculate the users' local time, rather than manually putting in a timezone offset, which changes depending on DST.
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
 - [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
