### PR TITLE
fix: set default language to "en"

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -67,7 +67,7 @@ export default {
 
     this.$store.dispatch(
       'ui/setLanguage',
-      localStorage.getItem('language') || 'en-gb'
+      localStorage.getItem('language') || 'en'
     )
 
     this.$store.dispatch(

--- a/src/store/modules/ui.js
+++ b/src/store/modules/ui.js
@@ -3,7 +3,7 @@ import * as types from '../mutation-types'
 export default {
   namespaced: true,
   state: {
-    language: 'en-gb',
+    language: 'en',
     locale: navigator.language || 'en-gb',
     nightMode: false,
     priceChart: true,


### PR DESCRIPTION
## Proposed changes

Should fix the issues with certain texts not being translated properly, as we don't have an `en-gb.json` file