### PR TITLE
fix: add "en" to languages for backwards comp

### DIFF
--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -5,6 +5,7 @@ import store from '@/store'
 Vue.use(VueI18n)
 
 const messages = {
+  en: require('./en.json'),
   'en-gb': require('./en.json'),
   'en-us': require('./en.json'),
   nl: require('./nl.json'),


### PR DESCRIPTION
## Proposed changes

Adds 'en' as language as that is what it used to be and people that have not cleared their cache since the change will have weird translations in some places:

<img width="499" alt="schermafbeelding 2018-12-09 om 16 05 41" src="https://user-images.githubusercontent.com/35610748/49699059-7df66500-fbcc-11e8-8680-98b7da174e5a.png">

fixes #489 

