### PR TITLE
fix: render chart only if token is set

### DIFF
--- a/src/components/ChartWrapper.vue
+++ b/src/components/ChartWrapper.vue
@@ -128,6 +128,7 @@ export default {
 
   computed: {
     ...mapGetters('currency', { currencyName: 'name' }),
+    ...mapGetters('network', ['token'])
   },
 
   mounted() {
@@ -145,7 +146,9 @@ export default {
     period(type) {
       this.type = type
 
-      this.renderChart()
+      if (!!this.token) {
+        this.renderChart()
+      }
     },
 
     async renderChart(type) {


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The app was trying to render the chart before the network token had been set, which caused the underlying API requests to fail. Fixes #496.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes