### PR TITLE
fix: price-chart not visible on resize

### DIFF
--- a/src/components/ChartWrapper.vue
+++ b/src/components/ChartWrapper.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div :key="componentKey">
     <div class="flex justify-between items-center px-10 py-8">
       <h2 class="text-white m-0 text-xl font-normal">{{ $t("Price in") }} {{ currencyName }}</h2>
       <div>
@@ -26,6 +26,7 @@ export default {
 
   data: () => ({
     type: 'day',
+    componentKey: 0,
     chartData: {},
     options: {
       showScale: true,
@@ -132,6 +133,7 @@ export default {
   },
 
   mounted() {
+    window.addEventListener('resize', this.handleResize)
     this.prepareComponent()
   },
 
@@ -182,6 +184,12 @@ export default {
 
     watchNetworkToken() {
       this.$store.watch((state) => state.network.token, (value) => this.renderChart())
+    },
+
+    handleResize() {
+      // trick to re-mount the chart on resize
+      // https://stackoverflow.com/questions/47459837/how-to-re-mount-a-component
+      this.componentKey++
     },
   }
 }


### PR DESCRIPTION
How to reproduce this bug-
- Keep the browser window small, so that chart wont load
- reload/open the explorer
- now resize to bigger
- price-chart isn't visible
this is becoz on maintainAspectRatio option. After searching lots of forums, best solution appears to be as follows.

## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
- add event listenor for window resize
- change component key to remount the chart on resize

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
