### PR TITLE
feat: Reset the headerType to null (default) when clicking outside search bar

### DIFF
--- a/src/components/header/Main.vue
+++ b/src/components/header/Main.vue
@@ -8,7 +8,7 @@
     </router-link>
 
     <div class="w-full relative hidden xl:flex">
-      <header-search v-if="headerType === 'search'"></header-search>
+      <header-search v-if="headerType === 'search'" v-click-outside="closeHeader"></header-search>
 
       <header-desktop-currencies v-else-if="headerType === 'currencies'"></header-desktop-currencies>
 
@@ -58,6 +58,12 @@ export default {
   computed: {
     ...mapGetters('ui', ['headerType', 'menuVisible']),
   },
+
+  methods: {
+    closeHeader () {
+      this.$store.dispatch('ui/setHeaderType', null)
+    }
+  }
 }
 </script>
 

--- a/src/directives/click-outside.js
+++ b/src/directives/click-outside.js
@@ -1,0 +1,16 @@
+export default {
+    bind: function (el, binding, vnode) {
+      el.clickOutsideEvent = function (ev) {
+        var path = ev.path || (ev.composedPath ? ev.composedPath() : undefined)
+        if ((path ? path.indexOf(el) < 0 : !el.contains(ev.target))) {
+          return binding.value.call(vnode.context, ev)
+        }
+      }
+  
+      document.documentElement.addEventListener('click', el.clickOutsideEvent, false)
+    },
+    unbind: function (el) {
+      document.documentElement.removeEventListener('click', el.clickOutsideEvent, false)
+    }
+  }
+  

--- a/src/directives/index.js
+++ b/src/directives/index.js
@@ -1,0 +1,7 @@
+import clickOutside from './click-outside'
+
+export default {
+  install (Vue) {
+    Vue.directive('click-outside', clickOutside)
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ import App from './App'
 import router from './router'
 import store from './store'
 import i18n from './i18n'
+import directives from './directives'
 import VTooltip from 'v-tooltip'
 import TableComponent from 'vue-table-component'
 import _ from 'lodash'
@@ -27,6 +28,8 @@ new Vue({
   components: { App },
   template: '<App/>',
 })
+
+Vue.use(directives)
 
 Vue.use(VTooltip, {
   defaultHtml: false,


### PR DESCRIPTION
Fixes #517 
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

It didn't feel intuitive that the header didn't reset to show more relevant options when I wanted to "cancel" a search by clicking outside of the search bar.

 - Add and register the click-outside directive
 - Implement click-outside with simple `closeHeader()` function in Header/Main.vue -> methods

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
