### PR TITLE
fix: responsive wallet link

### DIFF
--- a/src/components/links/Wallet.vue
+++ b/src/components/links/Wallet.vue
@@ -19,7 +19,10 @@
       <router-link v-else v-tooltip="getAddress()" :to="{ name: 'wallet', params: { address: walletAddress } }">
         <span v-if="hasDefaultSlot"><slot></slot></span>
         <span v-else-if="delegate">{{ delegate.username }}</span>
-        <span v-else-if="address">{{ trunc ? truncate(address) : address }}</span>
+        <span v-else-if="address">
+          <span class="hidden md:inline-block">{{ trunc ? truncate(address) : address }}</span>
+          <span class="md:hidden">{{ truncate(address) }}</span>
+        </span>
       </router-link>
     </template>
 

--- a/src/pages/Transaction.vue
+++ b/src/pages/Transaction.vue
@@ -38,15 +38,15 @@
         <div class="px-5 sm:px-10">
           <div class="list-row-border-b">
             <div>{{ $t("Sender") }}</div>
-            <div class="truncate">
-              <link-wallet :address="transaction.senderId">{{ transaction.senderId }}</link-wallet>
+            <div>
+              <link-wallet :address="transaction.senderId" :trunc="false"></link-wallet>
             </div>
           </div>
 
           <div class="list-row-border-b">
             <div>{{ $t("Recipient") }}</div>
-            <div class="truncate">
-              <link-wallet :address="transaction.recipientId" :type="transaction.type" :asset="transaction.asset">{{ transaction.recipientId }}</link-wallet>
+            <div>
+              <link-wallet :address="transaction.recipientId" :type="transaction.type" :asset="transaction.asset" :trunc="false"></link-wallet>
             </div>
           </div>
 

--- a/test/unit/specs/components/links/Wallet.spec.js
+++ b/test/unit/specs/components/links/Wallet.spec.js
@@ -39,7 +39,7 @@ describe('Link/Wallet', () => {
     expect(wrapper.contains('a')).toBe(true)
     expect(wrapper.findAll('a')).toHaveLength(1)
     expect(wrapper.text()).toEqual(expect.stringContaining(testAddress))
-    expect(wrapper.text()).not.toEqual(expect.stringContaining(mixins.truncate(testAddress)))
+    expect(wrapper.text()).toEqual(expect.stringContaining(mixins.truncate(testAddress)))
   })
 
   it('Should display a truncated link to a wallet', () => {


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The reason for the refactoring in the first place was to allow the default slot to be used on small and large screens, but that didn't fully handle the display on small screens, resulting in a full sender / recipient address instead of the truncated one. Fixes #533.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes