### PR TITLE
fix: cast type to integer so it properly filters "all"

### DIFF
--- a/src/pages/Transactions.vue
+++ b/src/pages/Transactions.vue
@@ -63,7 +63,7 @@ export default {
   },
 
   async beforeRouteEnter (to, from, next) {
-    const response = await TransactionService.filterByType(to.params.page, localStorage.getItem('transactionType'))
+    const response = await TransactionService.filterByType(to.params.page, Number(localStorage.getItem('transactionType')) || -1)
     next(vm => {
       vm.currentPage = to.params.page
       vm.setTransactions(response)
@@ -72,7 +72,7 @@ export default {
 
   async beforeRouteUpdate (to, from, next) {
     this.transactions = null
-    const response = await TransactionService.filterByType(to.params.page, localStorage.getItem('transactionType'))
+    const response = await TransactionService.filterByType(to.params.page, Number(localStorage.getItem('transactionType')) || -1)
     this.currentPage = to.params.page
     this.setTransactions(response)
     next()


### PR DESCRIPTION
## Proposed changes

Fixes the transactions no longer being loaded if you set the transaction type to `All`.

How to reproduce the current issue:

1. Go to https://explorer.ark.io
2. Click 'show more'
3. Set filter type to 'All' (or to 'Vote' first and then back to 'All')
4. Go back to homepage
5. Click on 'show more' again and the console will show an error and you will not navigate to the transaction page

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
