### PR TITLE
fix: truncation of block id

### DIFF
--- a/src/components/block/Identity.vue
+++ b/src/components/block/Identity.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="mb-5 bg-theme-feature-background xl:rounded-lg flex flex-col md:flex-row items-center px-5 sm:px-10 py-8">
-    <div class="flex items-center flex-auto w-full md:w-auto mb-5 md:mb-0">
+    <div class="flex items-center flex-auto w-full md:w-auto mb-5 md:mb-0 truncate md:mr-10">
       <img class="mr-6" src="@/assets/images/icons/block.svg" />
       <div class="flex-auto min-w-0">
         <div class="text-grey mb-2">{{ $t("Block ID") }}</div>
@@ -15,7 +15,7 @@
         </div>
       </div>
     </div>
-    <div class="flex w-full md:block md:w-auto justify-between">
+    <div class="flex w-full md:block md:w-auto justify-between whitespace-no-wrap">
       <button @click="prevHandler" :disabled="isFirstBlock" class="block-pager-button mr-5">
         <svg
          class="inline"

--- a/src/components/block/Identity.vue
+++ b/src/components/block/Identity.vue
@@ -6,7 +6,12 @@
         <div class="text-grey mb-2">{{ $t("Block ID") }}</div>
         <div class="flex">
           <div class="text-xl text-white semibold truncate">
-            <span class="mr-2">{{ block.id ? block.id : "&nbsp;" }}</span>
+            <span
+              v-tooltip="block.id"
+              class="mr-2"
+            >
+              {{ block.id }}
+            </span>
           </div>
           <clipboard
             v-if="block.id"


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

![image](https://user-images.githubusercontent.com/6547002/55197104-c6548580-51b1-11e9-95b6-66abe78e53db.png)

The div containing the block id was not truncated correctly, causing the buttons to misalign.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes