### PR TITLE
fix: display second signature icon

### DIFF
--- a/src/components/wallet/Details.vue
+++ b/src/components/wallet/Details.vue
@@ -17,13 +17,8 @@
       >
         <div class="flex items-center text-grey mb-2">
           <span>{{ $t("Address") }}</span>
-          <span
-            v-if="name"
-            class="ml-2 text-white semibold"
-          >{{ name }}</span>
-
           <svg
-            v-if="wallet.secondSignature"
+            v-if="wallet.secondPublicKey"
             v-tooltip="$t('Second signature enabled')"
             class="fill-current ml-2"
             viewBox="0 0 448 512"
@@ -38,6 +33,12 @@
               d="M400 224h-24v-72C376 68.2 307.8 0 224 0S72 68.2 72 152v72H48c-26.5 0-48 21.5-48 48v192c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V272c0-26.5-21.5-48-48-48zm-104 0H152v-72c0-39.7 32.3-72 72-72s72 32.3 72 72v72z"
             />
           </svg>
+          <span
+            v-if="name"
+            class="ml-2 text-white semibold"
+          >
+            {{ name }}
+          </span>
           <svg
             v-if="name"
             v-tooltip="$t('This is a verified address')"
@@ -74,7 +75,7 @@
         </div>
         <div class="flex">
           <div class="text-lg text-white semibold truncate mr-2">
-            <span class="mr-2">{{ wallet.publicKey }}</span>
+            <span>{{ wallet.publicKey }}</span>
           </div>
           <Clipboard
             v-if="wallet.publicKey"
@@ -180,7 +181,7 @@
             <div class="flex items-center text-grey mb-2">
               <span class="mr-2">{{ $t("Address") }}</span>
               <svg
-                v-if="wallet.secondSignature"
+                v-if="wallet.secondPublicKey"
                 v-tooltip="{ trigger: 'click', content: $t('Second signature enabled') }"
                 class="fill-current"
                 viewBox="0 0 448 512"


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The second signature icon was not being displayed anymore.

![image](https://user-images.githubusercontent.com/6547002/55707365-b7f13f80-59e3-11e9-9bd1-99ffdd222c28.png)

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes