### PR TITLE
fix: copy button on iOS

### DIFF
--- a/src/components/utils/Clipboard.vue
+++ b/src/components/utils/Clipboard.vue
@@ -55,24 +55,25 @@ export default {
 
     copy () {
       let textArea = document.createElement('textarea')
-      const isiOSDevice = navigator.userAgent.match(/ipad|iphone/i)
       textArea.value = this.value
       textArea.style.cssText =
         'position:absolute;top:0;left:0;z-index:-9999;opacity:0;'
 
       document.body.appendChild(textArea)
 
+      const isiOSDevice = navigator.userAgent.match(/ipad|iphone/i)
+
       if (isiOSDevice) {
-        let editable = textArea.contentEditable
-        let readOnly = textArea.readOnly
+        const editable = textArea.contentEditable
+        const readOnly = textArea.readOnly
 
         textArea.contentEditable = true
         textArea.readOnly = false
 
-        let range = document.createRange()
+        const range = document.createRange()
         range.selectNodeContents(textArea)
 
-        let selection = window.getSelection()
+        const selection = window.getSelection()
         selection.removeAllRanges()
         selection.addRange(range)
 

--- a/src/components/utils/Clipboard.vue
+++ b/src/components/utils/Clipboard.vue
@@ -55,12 +55,33 @@ export default {
 
     copy () {
       let textArea = document.createElement('textarea')
+      let isiOSDevice = navigator.userAgent.match(/ipad|iphone/i)
       textArea.value = this.value
       textArea.style.cssText =
         'position:absolute;top:0;left:0;z-index:-9999;opacity:0;'
 
       document.body.appendChild(textArea)
-      textArea.select()
+
+      if (isiOSDevice) {
+        let editable = textArea.contentEditable
+        let readOnly = textArea.readOnly
+
+        textArea.contentEditable = true
+        textArea.readOnly = false
+
+        let range = document.createRange()
+        range.selectNodeContents(textArea)
+
+        let selection = window.getSelection()
+        selection.removeAllRanges()
+        selection.addRange(range)
+
+        textArea.setSelectionRange(0, 999999)
+        textArea.contentEditable = editable
+        textArea.readOnly = readOnly
+      } else {
+        textArea.select()
+      }
 
       this.copying = true
       setTimeout(() => (this.copying = false), 1200)

--- a/src/components/utils/Clipboard.vue
+++ b/src/components/utils/Clipboard.vue
@@ -55,7 +55,7 @@ export default {
 
     copy () {
       let textArea = document.createElement('textarea')
-      let isiOSDevice = navigator.userAgent.match(/ipad|iphone/i)
+      const isiOSDevice = navigator.userAgent.match(/ipad|iphone/i)
       textArea.value = this.value
       textArea.style.cssText =
         'position:absolute;top:0;left:0;z-index:-9999;opacity:0;'


### PR DESCRIPTION
## Proposed changes
A possible solution to issue #532 
A workaround for iOS devices where copy is not supported on mobile devices. 

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
I'm not sure how to add appropriate tests that would prove the fix on iOS, I started a ngrok-service to check my local-server changes on my mobile (iOS 12, iPhone XS)  
