### PR TITLE
refactor: close currency header immediately on change

### DIFF
--- a/__tests__/unit/specs/components/header/Currencies.spec.js
+++ b/__tests__/unit/specs/components/header/Currencies.spec.js
@@ -63,10 +63,10 @@ describe('header/currencies/Desktop', () => {
 
     wrapper.vm.$nextTick(() => {
       expect(dispatchMock).toHaveBeenCalledTimes(4)
-      expect(dispatchMock).toHaveBeenNthCalledWith(1, 'currency/setName', 'USD')
-      expect(dispatchMock).toHaveBeenNthCalledWith(2, 'currency/setRate', 12.34)
-      expect(dispatchMock).toHaveBeenNthCalledWith(3, 'currency/setSymbol', '$')
-      expect(dispatchMock).toHaveBeenNthCalledWith(4, 'ui/setHeaderType', null)
+      expect(dispatchMock).toHaveBeenNthCalledWith(1, 'ui/setHeaderType', null)
+      expect(dispatchMock).toHaveBeenNthCalledWith(2, 'currency/setName', 'USD')
+      expect(dispatchMock).toHaveBeenNthCalledWith(3, 'currency/setRate', 12.34)
+      expect(dispatchMock).toHaveBeenNthCalledWith(4, 'currency/setSymbol', '$')
       done()
     })
   })

--- a/__tests__/unit/specs/components/header/Currencies.spec.js
+++ b/__tests__/unit/specs/components/header/Currencies.spec.js
@@ -107,10 +107,10 @@ describe('header/currencies/Mobile', () => {
 
     wrapper.vm.$nextTick(() => {
       expect(dispatchMock).toHaveBeenCalledTimes(4)
-      expect(dispatchMock).toHaveBeenNthCalledWith(1, 'currency/setName', 'USD')
-      expect(dispatchMock).toHaveBeenNthCalledWith(2, 'currency/setRate', 12.34)
-      expect(dispatchMock).toHaveBeenNthCalledWith(3, 'currency/setSymbol', '$')
-      expect(dispatchMock).toHaveBeenNthCalledWith(4, 'ui/setHeaderType', null)
+      expect(dispatchMock).toHaveBeenNthCalledWith(1, 'ui/setHeaderType', null)
+      expect(dispatchMock).toHaveBeenNthCalledWith(2, 'currency/setName', 'USD')
+      expect(dispatchMock).toHaveBeenNthCalledWith(3, 'currency/setRate', 12.34)
+      expect(dispatchMock).toHaveBeenNthCalledWith(4, 'currency/setSymbol', '$')
       done()
     })
   })

--- a/src/components/header/currencies/Desktop.vue
+++ b/src/components/header/currencies/Desktop.vue
@@ -32,6 +32,8 @@ export default {
 
   methods: {
     async setCurrency (currency, symbol) {
+      this.$store.dispatch('ui/setHeaderType', null)
+
       const rate = await CryptoCompareService.price(currency)
       this.storeCurrency(currency, rate, symbol)
     },
@@ -40,8 +42,6 @@ export default {
       this.$store.dispatch('currency/setName', currency)
       this.$store.dispatch('currency/setRate', rate)
       this.$store.dispatch('currency/setSymbol', symbol)
-
-      this.$store.dispatch('ui/setHeaderType', null)
     }
   }
 }

--- a/src/components/header/currencies/Mobile.vue
+++ b/src/components/header/currencies/Mobile.vue
@@ -29,6 +29,8 @@ export default {
 
   methods: {
     async setCurrency (currency, symbol) {
+      this.$store.dispatch('ui/setHeaderType', null)
+
       const rate = await CryptoCompareService.price(currency)
       this.storeCurrency(currency, rate, symbol)
     },
@@ -37,8 +39,6 @@ export default {
       this.$store.dispatch('currency/setName', currency)
       this.$store.dispatch('currency/setRate', rate)
       this.$store.dispatch('currency/setSymbol', symbol)
-
-      this.$store.dispatch('ui/setHeaderType', null)
     }
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

User won't like being stuck on the currency menu while we fetch the data. Instead, it will feel better if it closes immediately and changes in background.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [x] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [x] Other, please describe: UI Enhancement

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
