### PR TITLE
test: adapt unit tests to new api responses and use legacy jsonwire mode in e2e tests

### DIFF
--- a/__tests__/e2e/nightwatch.conf.js
+++ b/__tests__/e2e/nightwatch.conf.js
@@ -21,26 +21,28 @@ module.exports = {
   test_settings: {
     default: {
       webdriver: {
+        use_legacy_jsonwire: true,
+        default_path_prefix: '/wd/hub',
         webdriver_port: 4444,
         webdriver_host: '127.0.0.1'
       },
       silent: true,
       globals: {
         devServerURL: 'http://127.0.0.1:' + (process.env.PORT || config.dev.port)
-      },
-      desiredCapabilities: {
-        chromeOptions: {
-          args: [
-            'window-size=1920,1080',
-            'disable-dev-shm-usage'
-          ]
-        }
       }
     },
 
     chrome: {
       desiredCapabilities: {
         browserName: 'chrome',
+        'goog:chromeOptions': {
+          w3c: false,
+          prefs: { 'profile.managed_default_content_settings.notifications': 1 },
+          args: [
+            'window-size=1920,1080',
+            'disable-dev-shm-usage'
+          ]
+        },
         javascriptEnabled: true,
         acceptSslCerts: true
       }

--- a/__tests__/unit/specs/services/block.spec.js
+++ b/__tests__/unit/specs/services/block.spec.js
@@ -10,6 +10,7 @@ const blockPropertyArray = [
   'payload',
   'generator',
   'signature',
+  'confirmations',
   'transactions',
   'timestamp'
 ].sort()

--- a/__tests__/unit/specs/services/delegate.spec.js
+++ b/__tests__/unit/specs/services/delegate.spec.js
@@ -18,11 +18,9 @@ const voterPropertyArray = [
   'address',
   'balance',
   'isDelegate',
-  'publicKey',
-  'secondPublicKey',
-  'username',
-  'vote'
+  'publicKey'
 ].sort()
+// Note: secondPublicKey, username and vote can also be returned, but are optional
 
 describe('Delegate Service', () => {
   beforeAll(() => {
@@ -41,7 +39,7 @@ describe('Delegate Service', () => {
   it('should retrieve the voters based on given delegate address', async () => {
     const { meta, data } = await DelegateService.voters('ARAq9nhjCxwpWnGKDgxveAJSijNG8Y6dFQ')
     data.forEach(voter => {
-      expect(Object.keys(voter).sort()).toEqual(voterPropertyArray)
+      expect(Object.keys(voter).sort()).toEqual(expect.arrayContaining(voterPropertyArray))
     })
   })
 

--- a/__tests__/unit/specs/services/node.spec.js
+++ b/__tests__/unit/specs/services/node.spec.js
@@ -17,7 +17,6 @@ describe('Node Service', () => {
       'ports',
       'slip44',
       'constants',
-      'feeStatistics',
       'transactionPool',
       'wif'
     ].sort())

--- a/__tests__/unit/specs/services/search.spec.js
+++ b/__tests__/unit/specs/services/search.spec.js
@@ -1,6 +1,25 @@
 import SearchService from '@/services/search'
 import store from '@/store'
 
+const walletPropertyArray = [
+  'address',
+  'balance',
+  'isDelegate',
+  'publicKey'
+].sort()
+// Note: secondPublicKey, username and vote can also be returned, but are optional
+
+const delegatePropertyArray = [
+  'username',
+  'address',
+  'publicKey',
+  'votes',
+  'rank',
+  'blocks',
+  'production',
+  'forged'
+].sort()
+
 describe('Search Service', () => {
   beforeAll(() => {
     jest.setTimeout(60000)
@@ -8,53 +27,27 @@ describe('Search Service', () => {
     store.dispatch('network/setServer', 'https://explorer.ark.io/api/v2')
   })
 
-  it('should return address when searching for existing wallet', async () => {
+  it('should return an object when searching for existing wallet', async () => {
     const data = await SearchService.walletByAddress('ATsPMTAHNsUwKedzNpjTNRfcj1oRGaX5xC')
-    expect(Object.keys(data).sort()).toEqual([
-      'address',
-      'balance',
-      'isDelegate',
-      'publicKey',
-      'secondPublicKey',
-      'username',
-      'vote'
-    ].sort())
+    expect(Object.keys(data).sort()).toEqual(expect.arrayContaining(walletPropertyArray))
   })
 
   it('should fail when searching for non-existing wallet', async () => {
     await expect(SearchService.walletByAddress('ATsPMTAHNsUwKedzNpjTNRfcj1oRGaX5xz')).rejects.toThrow()
   })
 
-  it('should return delegate address when searching for existing username', async () => {
+  it('should return an object when searching for existing username', async () => {
     const data = await SearchService.delegateByQuery('arkpool')
-    expect(Object.keys(data).sort()).toEqual([
-      'username',
-      'address',
-      'publicKey',
-      'votes',
-      'rank',
-      'blocks',
-      'production',
-      'forged'
-    ].sort())
+    expect(Object.keys(data).sort()).toEqual(delegatePropertyArray)
   })
 
   it('should fail when searching for non-matching username', async () => {
     await expect(SearchService.delegateByQuery('asdhfajksdhfakjsdfasdf')).rejects.toThrow()
   })
 
-  it('should return delegate address when searching for existing public key', async () => {
+  it('should return an object when searching for existing public key', async () => {
     const data = await SearchService.delegateByQuery('02b1d2ea7c265db66087789f571fceb8cc2b2d89e296ad966efb8ed51855f2ae0b')
-    expect(Object.keys(data).sort()).toEqual([
-      'username',
-      'address',
-      'publicKey',
-      'votes',
-      'rank',
-      'blocks',
-      'production',
-      'forged'
-    ].sort())
+    expect(Object.keys(data).sort()).toEqual(delegatePropertyArray)
   })
 
   it('should fail when searching for non-matching public key', async () => {
@@ -72,6 +65,7 @@ describe('Search Service', () => {
       'payload',
       'generator',
       'signature',
+      'confirmations',
       'transactions',
       'timestamp'
     ].sort())
@@ -91,6 +85,7 @@ describe('Search Service', () => {
       'amount',
       'fee',
       'sender',
+      'senderPublicKey',
       'recipient',
       'signature',
       'confirmations',

--- a/__tests__/unit/specs/services/wallet.spec.js
+++ b/__tests__/unit/specs/services/wallet.spec.js
@@ -5,11 +5,9 @@ const walletPropertyArray = [
   'address',
   'balance',
   'isDelegate',
-  'publicKey',
-  'secondPublicKey',
-  'username',
-  'vote'
+  'publicKey'
 ].sort()
+// Note: secondPublicKey, username and vote can also be returned, but are optional
 
 describe('Wallet Service', () => {
   beforeAll(() => {
@@ -18,16 +16,7 @@ describe('Wallet Service', () => {
 
   it('should return address when searching for existing wallet', async () => {
     const data = await WalletService.find('ATsPMTAHNsUwKedzNpjTNRfcj1oRGaX5xC')
-    // Response should contain all these properties
-    expect(Object.keys(data).sort()).toEqual([
-      'address',
-      'balance',
-      'isDelegate',
-      'publicKey',
-      'secondPublicKey',
-      'username',
-      'vote'
-    ].sort())
+    expect(Object.keys(data).sort()).toEqual(expect.arrayContaining(walletPropertyArray))
   })
 
   it('should fail when searching for incorrect wallet address', async () => {
@@ -38,7 +27,7 @@ describe('Wallet Service', () => {
     const { data } = await WalletService.top()
     expect(data).toHaveLength(25)
     data.forEach(wallet => {
-      expect(Object.keys(wallet).sort()).toEqual(walletPropertyArray.sort())
+      expect(Object.keys(wallet).sort()).toEqual(expect.arrayContaining(walletPropertyArray))
     })
   })
 
@@ -46,7 +35,7 @@ describe('Wallet Service', () => {
     const { data } = await WalletService.top(1)
     expect(data).toHaveLength(25)
     data.forEach(wallet => {
-      expect(Object.keys(wallet).sort()).toEqual(walletPropertyArray.sort())
+      expect(Object.keys(wallet).sort()).toEqual(expect.arrayContaining(walletPropertyArray))
     })
     expect(data.sort((a, b) => a.balance > b.balance)).toEqual(data)
   })
@@ -55,7 +44,7 @@ describe('Wallet Service', () => {
     const { data } = await WalletService.top(2, 20)
     expect(data).toHaveLength(20)
     data.forEach(wallet => {
-      expect(Object.keys(wallet).sort()).toEqual(walletPropertyArray.sort())
+      expect(Object.keys(wallet).sort()).toEqual(expect.arrayContaining(walletPropertyArray))
     })
     expect(data.sort((a, b) => a.balance > b.balance)).toEqual(data)
   })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Core v2.4 slightly changes some API responses. This PR adjusts the unit tests to account for those changes.

It also sets the chromedriver mode to use the legacy jsonwire. This is a functional workaround until chromedriver has fully migrated to the W3C protocol.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [x] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
