### PR TITLE
fix: include delegates that never forged in not-forging count

### DIFF
--- a/__tests__/unit/specs/services/forging.spec.js
+++ b/__tests__/unit/specs/services/forging.spec.js
@@ -64,6 +64,7 @@ describe('Forging Service', () => {
       forging: 1,
       missedBlock: 1,
       notForging: 1,
+      neverForged: 1,
       remainingBlocks: 51
     })
   })

--- a/src/components/monitor/ForgingStats.vue
+++ b/src/components/monitor/ForgingStats.vue
@@ -36,7 +36,7 @@
       </div>
       <div class="p-0 sm:pl-4">
         <div class="text-3xl semibold">
-          {{ totals.notForging }}
+          {{ totals.notForging + totals.neverForged }}
         </div>
         <div class="text-grey">
           {{ $t("Not forging") }}

--- a/src/services/forging.js
+++ b/src/services/forging.js
@@ -55,6 +55,7 @@ class ForgingService {
     let forging = 0
     let missedBlock = 0
     let notForging = 0
+    let neverForged = 0
 
     const height = store.getters['network/height']
     const activeDelegates = store.getters['network/activeDelegates']
@@ -78,6 +79,11 @@ class ForgingService {
           notForging++
           break
         }
+        case ForgeStatus.NEVER_FORGED:
+        {
+          neverForged++
+          break
+        }
         default:
         {
           break
@@ -89,6 +95,7 @@ class ForgingService {
       forging,
       missedBlock,
       notForging,
+      neverForged,
       remainingBlocks
     }
   }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Adds delegates that never forged to the not forging count. Closes #647.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
