### PR TITLE
feat: fetch delegate data every two minutes

### DIFF
--- a/__tests__/unit/specs/components/links/LinkWallet.spec.js
+++ b/__tests__/unit/specs/components/links/LinkWallet.spec.js
@@ -21,6 +21,8 @@ describe('Compontents > Links > Wallet', () => {
   const testDelegateAddress = 'ALgvTAoz5Vi9easHqBK6aEMKatHb4beCXm'
   const testDelegatePublicKey = '03aa4863c93d170d89675a6e381d08a451c1067fc0f6fed479571d9ecb178963b3'
 
+  const delegates = [{ username: 'TestDelegate', address: testDelegateAddress, publicKey: testDelegatePublicKey }]
+
   it('should display a full link to a wallet', () => {
     const wrapper = mount(LinkWallet, {
       propsData: {
@@ -92,7 +94,7 @@ describe('Compontents > Links > Wallet', () => {
   })
 
   it('should display the name of a delegate', done => {
-    store.dispatch('delegates/setDelegates', [{ username: 'TestDelegate', address: testDelegateAddress, publicKey: testDelegatePublicKey }])
+    store.dispatch('delegates/setDelegates', { delegates })
     const wrapper = mount(LinkWallet, {
       propsData: {
         address: testDelegateAddress,
@@ -119,7 +121,7 @@ describe('Compontents > Links > Wallet', () => {
   })
 
   it('should also find the delegate by public key', done => {
-    store.dispatch('delegates/setDelegates', [{ username: 'TestDelegate', address: testDelegateAddress, publicKey: testDelegatePublicKey }])
+    store.dispatch('delegates/setDelegates', { delegates })
     const wrapper = mount(LinkWallet, {
       propsData: {
         publicKey: testDelegatePublicKey,
@@ -179,7 +181,7 @@ describe('Compontents > Links > Wallet', () => {
     })
 
     it('should display Vote for type 3', () => {
-      store.dispatch('delegates/setDelegates', [{ username: 'TestDelegate', address: testDelegateAddress, publicKey: testDelegatePublicKey }])
+      store.dispatch('delegates/setDelegates', { delegates })
 
       const wrapper = mount(LinkWallet, {
         propsData: {

--- a/__tests__/unit/specs/components/utils/TransactionAmount.spec.js
+++ b/__tests__/unit/specs/components/utils/TransactionAmount.spec.js
@@ -39,7 +39,10 @@ describe('Components > Utils > TransactionAmount', () => {
         transaction: {
           sender: incomingAddress,
           recipient: outgoingAddress,
-          amount: 100000000
+          amount: 100000000,
+          timestamp: {
+            unix: 1
+          }
         },
         type: 0
       },
@@ -69,7 +72,10 @@ describe('Components > Utils > TransactionAmount', () => {
         transaction: {
           sender: outgoingAddress,
           recipient: incomingAddress,
-          amount: 100000000
+          amount: 100000000,
+          timestamp: {
+            unix: 1
+          }
         },
         type: 0
       },
@@ -99,7 +105,10 @@ describe('Components > Utils > TransactionAmount', () => {
         transaction: {
           sender: incomingAddress,
           recipient: incomingAddress,
-          amount: 100000000
+          amount: 100000000,
+          timestamp: {
+            unix: 1
+          }
         },
         type: 1
       },

--- a/__tests__/unit/specs/store/modules/delegates.spec.js
+++ b/__tests__/unit/specs/store/modules/delegates.spec.js
@@ -7,7 +7,7 @@ const delegates = [
 
 describe('Store > Delegates', () => {
   it('should set the delegates rate', () => {
-    store.dispatch('delegates/setDelegates', delegates)
+    store.dispatch('delegates/setDelegates', { delegates })
 
     expect(store.getters['delegates/delegates']).toEqual(delegates)
   })

--- a/src/App.vue
+++ b/src/App.vue
@@ -32,8 +32,9 @@ export default {
 
   computed: {
     ...mapGetters('currency', { currencyName: 'name' }),
-    ...mapGetters('ui', ['language', 'locale', 'nightMode']),
-    ...mapGetters('network', ['token'])
+    ...mapGetters('delegates', ['stateHasDelegates']),
+    ...mapGetters('network', ['token']),
+    ...mapGetters('ui', ['language', 'locale', 'nightMode'])
   },
 
   async created () {
@@ -129,8 +130,19 @@ export default {
     },
 
     async updateDelegates () {
-      const delegates = await DelegateService.all()
-      this.$store.dispatch('delegates/setDelegates', delegates)
+      const fetchedAt = localStorage.getItem('delegatesFetchedAt')
+
+      if (!this.stateHasDelegates || !fetchedAt || this.updateRequired(fetchedAt)) {
+        const delegates = await DelegateService.all()
+        this.$store.dispatch('delegates/setDelegates', {
+          delegates,
+          timestamp: Math.floor(Date.now() / 1000)
+        })
+      }
+    },
+
+    updateRequired (timestamp) {
+      return timestamp < moment().subtract(2, 'minute').unix()
     },
 
     updateI18n () {

--- a/src/components/links/LinkWallet.vue
+++ b/src/components/links/LinkWallet.vue
@@ -176,7 +176,6 @@ export default {
     },
 
     findByPublicKey () {
-      console.log(this.delegates)
       this.delegate = this.delegates.find(d => d.publicKey === this.publicKey)
     },
 

--- a/src/components/links/LinkWallet.vue
+++ b/src/components/links/LinkWallet.vue
@@ -176,6 +176,7 @@ export default {
     },
 
     findByPublicKey () {
+      console.log(this.delegates)
       this.delegate = this.delegates.find(d => d.publicKey === this.publicKey)
     },
 

--- a/src/store/modules/delegates.js
+++ b/src/store/modules/delegates.js
@@ -4,7 +4,7 @@ export default {
   namespaced: true,
 
   state: {
-    delegates: [],
+    delegates: null,
     forged: []
   },
 
@@ -18,12 +18,16 @@ export default {
   },
 
   actions: {
-    setDelegates: ({ commit }, value) => {
+    setDelegates: ({ commit }, { delegates, timestamp }) => {
+      localStorage.setItem('delegates', JSON.stringify(delegates))
+      localStorage.setItem('delegatesFetchedAt', timestamp)
+
       commit({
         type: types.SET_DELEGATES,
-        value
+        value: delegates
       })
     },
+
     setForged: ({ commit }, value) => {
       commit({
         type: types.SET_FORGED,
@@ -33,19 +37,26 @@ export default {
   },
 
   getters: {
-    delegates: state => state.delegates,
+    delegates: state => {
+      return state.delegates ? state.delegates : (JSON.parse(localStorage.getItem('delegates')) || [])
+    },
+
     forged: state => state.forged,
 
-    byPublicKey: (state) => publicKey => {
-      return state.delegates.find(delegate => {
+    byPublicKey: (_, getters) => publicKey => {
+      return getters.delegates.find(delegate => {
         return delegate.publicKey === publicKey
       }) || null
     },
 
-    byAddress: state => address => {
-      return state.delegates.find(delegate => {
+    byAddress: (_, getters) => address => {
+      return getters.delegates.find(delegate => {
         return delegate.address === address
       }) || null
+    },
+
+    stateHasDelegates: state => {
+      return !!state.delegates
     }
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Implements #688.

It fetches the delegates upon visiting the explorer and subsequently every two minutes. The delegates are saved in `localStorage` so they are immediately available for the various components.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
