### PR TITLE
fix: pass sort params to tables

### DIFF
--- a/src/components/block/Transactions.vue
+++ b/src/components/block/Transactions.vue
@@ -5,7 +5,11 @@
     </h2>
     <section class="page-section py-5 md:py-10">
       <div class="hidden sm:block">
-        <TableTransactionsDesktop :transactions="transactions" />
+        <TableTransactionsDesktop
+          :transactions="transactions"
+          :sort-query="sortParams"
+          @on-sort-change="onSortChange"
+        />
       </div>
       <div class="sm:hidden">
         <TableTransactionsMobile :transactions="transactions" />
@@ -43,6 +47,21 @@ export default {
     transactions: null
   }),
 
+  computed: {
+    sortParams: {
+      get () {
+        return this.$store.getters['ui/transactionSortParams']
+      },
+
+      set (params) {
+        this.$store.dispatch('ui/setTransactionSortParams', {
+          field: params.field,
+          type: params.type
+        })
+      }
+    }
+  },
+
   watch: {
     block () {
       this.resetTransactions()
@@ -62,6 +81,10 @@ export default {
         const { data } = await TransactionService.byBlock(this.block.id)
         this.transactions = data
       }
+    },
+
+    onSortChange (params) {
+      this.sortParams = params
     }
   }
 }

--- a/src/components/tables/Blocks.vue
+++ b/src/components/tables/Blocks.vue
@@ -117,14 +117,16 @@ export default {
         {
           label: this.$t('BLOCK.TOTAL_FORGED'),
           field: 'forged.total',
-          type: 'number'
+          type: 'number',
+          thClass: 'end-cell lg:base-cell',
+          tdClass: 'end-cell lg:base-cell'
         },
         {
           label: this.$t('BLOCK.FEES'),
           field: 'forged.fee',
           type: 'number',
-          thClass: 'end-cell',
-          tdClass: 'end-cell'
+          thClass: 'end-cell hidden lg:table-cell',
+          tdClass: 'end-cell hidden lg:table-cell'
         }
       ]
 

--- a/src/components/wallet/Transactions.vue
+++ b/src/components/wallet/Transactions.vue
@@ -102,6 +102,19 @@ export default {
 
     isTypeReceived () {
       return this.type === 'received'
+    },
+
+    sortParams: {
+      get () {
+        return this.$store.getters['ui/transactionSortParams']
+      },
+
+      set (params) {
+        this.$store.dispatch('ui/setTransactionSortParams', {
+          field: params.field,
+          type: params.type
+        })
+      }
     }
   },
 
@@ -149,6 +162,10 @@ export default {
       this.type = type
 
       this.getTransactions()
+    },
+
+    onSortChange (params) {
+      this.sortParams = params
     }
   }
 }

--- a/src/pages/Block/Transactions.vue
+++ b/src/pages/Block/Transactions.vue
@@ -3,7 +3,11 @@
     <ContentHeader>{{ $t('COMMON.TRANSACTIONS') }}</ContentHeader>
     <section class="page-section py-5 md:py-10">
       <div class="hidden sm:block">
-        <TableTransactionsDesktop :transactions="transactions" />
+        <TableTransactionsDesktop
+          :transactions="transactions"
+          :sort-query="sortParams"
+          @on-sort-change="onSortChange"
+        />
       </div>
       <div class="sm:hidden">
         <TableTransactionsMobile :transactions="transactions" />
@@ -35,6 +39,19 @@ export default {
 
     id () {
       return this.$route.params.id
+    },
+
+    sortParams: {
+      get () {
+        return this.$store.getters['ui/transactionSortParams']
+      },
+
+      set (params) {
+        this.$store.dispatch('ui/setTransactionSortParams', {
+          field: params.field,
+          type: params.type
+        })
+      }
     }
   },
 
@@ -95,6 +112,10 @@ export default {
           page: this.currentPage
         }
       })
+    },
+
+    onSortChange (params) {
+      this.sortParams = params
     }
   }
 }

--- a/src/pages/Block/Transactions.vue
+++ b/src/pages/Block/Transactions.vue
@@ -34,7 +34,7 @@ export default {
 
   computed: {
     showPagination () {
-      return this.meta && this.meta.pageCount
+      return this.meta && this.meta.pageCount > 1
     },
 
     id () {

--- a/src/pages/Blocks.vue
+++ b/src/pages/Blocks.vue
@@ -4,7 +4,11 @@
 
     <section class="page-section py-5 md:py-10">
       <div class="hidden sm:block">
-        <TableBlocksDesktop :blocks="blocks" />
+        <TableBlocksDesktop
+          :blocks="blocks"
+          :sort-query="sortParams"
+          @on-sort-change="onSortChange"
+        />
       </div>
       <div class="sm:hidden">
         <TableBlocksMobile :blocks="blocks" />
@@ -32,6 +36,19 @@ export default {
   computed: {
     showPagination () {
       return this.meta && this.meta.pageCount
+    },
+
+    sortParams: {
+      get () {
+        return this.$store.getters['ui/blockSortParams']
+      },
+
+      set (params) {
+        this.$store.dispatch('ui/setBlockSortParams', {
+          field: params.field,
+          type: params.type
+        })
+      }
     }
   },
 
@@ -91,6 +108,10 @@ export default {
           page: this.currentPage
         }
       })
+    },
+
+    onSortChange (params) {
+      this.sortParams = params
     }
   }
 }

--- a/src/pages/Blocks.vue
+++ b/src/pages/Blocks.vue
@@ -63,7 +63,7 @@ export default {
       const { meta, data } = await BlockService.paginate(to.params.page)
 
       next(vm => {
-        vm.currentPage = to.params.page
+        vm.currentPage = Number(to.params.page)
         vm.setBlocks(data)
         vm.setMeta(meta)
       })
@@ -77,7 +77,7 @@ export default {
     try {
       const { meta, data } = await BlockService.paginate(to.params.page)
 
-      this.currentPage = to.params.page
+      this.currentPage = Number(to.params.page)
       this.setBlocks(data)
       this.setMeta(meta)
       next()

--- a/src/pages/TopWallets.vue
+++ b/src/pages/TopWallets.vue
@@ -41,7 +41,7 @@ export default {
     ...mapGetters('network', ['supply']),
 
     showPagination () {
-      return this.meta && this.meta.pageCount
+      return this.meta && this.meta.pageCount > 1
     },
 
     sortParams: {

--- a/src/pages/Transactions.vue
+++ b/src/pages/Transactions.vue
@@ -25,7 +25,11 @@
 
     <section class="page-section py-5 md:py-10">
       <div class="hidden sm:block">
-        <TableTransactionsDesktop :transactions="transactions" />
+        <TableTransactionsDesktop
+          :transactions="transactions"
+          :sort-query="sortParams"
+          @on-sort-change="onSortChange"
+        />
       </div>
       <div class="sm:hidden">
         <div class="mx-5 mb-4">
@@ -66,6 +70,19 @@ export default {
   computed: {
     showPagination () {
       return this.meta && this.meta.pageCount
+    },
+
+    sortParams: {
+      get () {
+        return this.$store.getters['ui/transactionSortParams']
+      },
+
+      set (params) {
+        this.$store.dispatch('ui/setTransactionSortParams', {
+          field: params.field,
+          type: params.type
+        })
+      }
     }
   },
 
@@ -148,6 +165,10 @@ export default {
           page: this.currentPage
         }
       })
+    },
+
+    onSortChange (params) {
+      this.sortParams = params
     }
   }
 }

--- a/src/pages/Transactions.vue
+++ b/src/pages/Transactions.vue
@@ -69,7 +69,7 @@ export default {
 
   computed: {
     showPagination () {
-      return this.meta && this.meta.pageCount
+      return this.meta && this.meta.pageCount > 1
     },
 
     sortParams: {

--- a/src/pages/Wallet/Blocks.vue
+++ b/src/pages/Wallet/Blocks.vue
@@ -25,7 +25,11 @@
 
     <section class="page-section py-5 md:py-10">
       <div class="hidden sm:block">
-        <TableBlocksDesktop :blocks="blocks" />
+        <TableBlocksDesktop
+          :blocks="blocks"
+          :sort-query="sortParams"
+          @on-sort-change="onSortChange"
+        />
       </div>
       <div class="sm:hidden">
         <TableBlocksMobile :blocks="blocks" />
@@ -58,6 +62,19 @@ export default {
 
     address () {
       return this.$route.params.address
+    },
+
+    sortParams: {
+      get () {
+        return this.$store.getters['ui/blockSortParams']
+      },
+
+      set (params) {
+        this.$store.dispatch('ui/setBlockSortParams', {
+          field: params.field,
+          type: params.type
+        })
+      }
     }
   },
 
@@ -132,6 +149,10 @@ export default {
           page: this.currentPage
         }
       })
+    },
+
+    onSortChange (params) {
+      this.sortParams = params
     }
   }
 }

--- a/src/pages/Wallet/Blocks.vue
+++ b/src/pages/Wallet/Blocks.vue
@@ -57,7 +57,7 @@ export default {
 
   computed: {
     showPagination () {
-      return this.meta && this.meta.pageCount
+      return this.meta && this.meta.pageCount > 1
     },
 
     address () {

--- a/src/pages/Wallet/Transactions.vue
+++ b/src/pages/Wallet/Transactions.vue
@@ -69,7 +69,11 @@
 
     <section class="page-section py-5 md:py-10">
       <div class="hidden sm:block">
-        <TableTransactionsDesktop :transactions="transactions" />
+        <TableTransactionsDesktop
+          :transactions="transactions"
+          :sort-query="sortParams"
+          @on-sort-change="onSortChange"
+        />
       </div>
       <div class="sm:hidden">
         <TableTransactionsMobile :transactions="transactions" />
@@ -106,6 +110,19 @@ export default {
 
     type () {
       return this.$route.params.type
+    },
+
+    sortParams: {
+      get () {
+        return this.$store.getters['ui/transactionSortParams']
+      },
+
+      set (params) {
+        this.$store.dispatch('ui/setTransactionSortParams', {
+          field: params.field,
+          type: params.type
+        })
+      }
     }
   },
 
@@ -172,6 +189,10 @@ export default {
           page: this.currentPage
         }
       })
+    },
+
+    onSortChange (params) {
+      this.sortParams = params
     }
   }
 }

--- a/src/pages/Wallet/Transactions.vue
+++ b/src/pages/Wallet/Transactions.vue
@@ -101,7 +101,7 @@ export default {
 
   computed: {
     showPagination () {
-      return this.meta && this.meta.pageCount
+      return this.meta && this.meta.pageCount > 1
     },
 
     address () {

--- a/src/pages/Wallet/Voters.vue
+++ b/src/pages/Wallet/Voters.vue
@@ -39,7 +39,7 @@ export default {
 
   computed: {
     showPagination () {
-      return this.meta && this.meta.pageCount
+      return this.meta && this.meta.pageCount > 1
     },
 
     address () {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

The sort params were saved and retrieved only on the latests transactions/blocks components.

Also hides the pagination if page count is below two.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
