### PR TITLE
fix: add shadows to dark-theme and fix dark style of dropdowns

### DIFF
--- a/src/components/ChartWrapper.vue
+++ b/src/components/ChartWrapper.vue
@@ -24,7 +24,7 @@
       :key="componentKey"
       :class="{ 'blur': hasError }"
     >
-      <div class="flex justify-between items-center px-10 py-8">
+      <div class="flex justify-between items-center px-10 pt-8 pb-4">
         <h2 class="text-white m-0 text-xl font-normal">
           {{ $t('MARKET_CHART.PRICE_IN') }} {{ currencyName }}
         </h2>
@@ -44,8 +44,8 @@
 
       <PriceChart
         :chart-data="chartData"
+        :styles="{ height: '308px' }"
         :options="options"
-        :height="314"
       />
     </div>
   </div>
@@ -86,7 +86,7 @@ export default {
         padding: {
           left: 50,
           right: 50,
-          top: 0,
+          top: 16,
           bottom: 50
         }
       },

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -9,7 +9,7 @@
     >
       <div class="flex items-center justify-center absolute inset-0">
         <div
-          class="modal-container bg-theme-page-background text-theme-text-content rounded shadow mx-auto relative p-10"
+          class="modal-container bg-theme-page-background text-theme-text-content rounded shadow-theme mx-auto relative p-10"
           @click.stop
         >
           <button

--- a/src/components/SelectionType.vue
+++ b/src/components/SelectionType.vue
@@ -35,7 +35,7 @@
 
       <ul
         v-show="isOpen"
-        class="absolute inset-x-0 mt-10 bg-white shadow rounded border overflow-hidden text-sm"
+        class="SelectionType--options inset-x-0 mt-10"
       >
         <li
           v-for="(type, index) in types"
@@ -77,7 +77,7 @@
 
       <ul
         v-show="isOpen"
-        class="absolute right-0 mt-2 bg-white shadow rounded border overflow-hidden text-sm"
+        class="SelectionType--options right-0 mt-2"
       >
         <li
           v-for="(type, index) in types"
@@ -164,3 +164,9 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.SelectionType--options {
+  @apply .absolute .bg-theme-content-background .shadow-theme .rounded .border .overflow-hidden .text-sm
+}
+</style>

--- a/src/components/wallet/Transactions.vue
+++ b/src/components/wallet/Transactions.vue
@@ -4,49 +4,38 @@
       {{ $t('COMMON.TRANSACTIONS') }}
     </h2>
     <section class="page-section py-5 md:py-10">
-      <nav class="mx-5 md:mx-10 mb-8 border-b flex items-end">
+      <nav class="TransactionsNavigation mx-5 md:mx-10">
         <div
-          :class="[
-            !isTypeSent && !isTypeReceived ? 'text-2xl border-blue text-theme-text-primary' : 'text-lg text-theme-text-secondary border-transparent',
-            'mr-4 py-4 px-2 cursor-pointer border-b-3 hover:text-theme-primary hover:border-blue'
-          ]"
+          :class="{ 'active': !isTypeSent && !isTypeReceived }"
+          class="TransactionsNavigation--tab"
           @click="setType('all')"
         >
           {{ $t('TRANSACTION.TYPES.ALL') }}
         </div>
         <div
-          :class="[
-            isTypeSent ? 'text-2xl border-blue text-theme-text-primary' : 'text-lg text-theme-text-secondary border-transparent',
-            !sentCount ? 'pointer-events-none text-theme-text-tertiary' : '',
-            'mr-4 py-4 px-2 cursor-pointer border-b-3 hover:text-theme-text-primary hover:border-blue'
-          ]"
+          :class="{
+            'active': isTypeSent,
+            'disabled': !sentCount
+          }"
+          class="TransactionsNavigation--tab"
           @click="setType('sent')"
         >
           {{ $t('TRANSACTION.TYPES.SENT') }}
-          <span
-            :class="isTypeSent ? 'text-theme-text-secondary' : 'text-theme-text-tertiary'"
-            class="text-xs text-theme-text-secondary"
-          >
-            {{ sentCount }}
-          </span>
+          <span>{{ sentCount }}</span>
         </div>
         <div
-          :class="[
-            isTypeReceived ? 'text-2xl border-blue text-theme-text-primary' : 'text-lg text-theme-text-secondary border-transparent',
-            !receivedCount ? 'pointer-events-none text-theme-text-tertiary' : '',
-            'mr-4 py-4 px-2 cursor-pointer border-b-3 hover:text-theme-text-primary hover:border-blue'
-          ]"
+          :class="{
+            'active': isTypeReceived,
+            'disabled': !receivedCount
+          }"
+          class="TransactionsNavigation--tab"
           @click="setType('received')"
         >
           {{ $t('TRANSACTION.TYPES.RECEIVED') }}
-          <span
-            :class="isTypeReceived ? 'text-theme-text-secondary' : 'text-theme-text-tertiary'"
-            class="text-xs"
-          >
-            {{ receivedCount }}
-          </span>
+          <span>{{ receivedCount }}</span>
         </div>
       </nav>
+
       <div class="hidden sm:block">
         <TableTransactionsDesktop
           :show-confirmations="true"
@@ -59,6 +48,7 @@
           :transactions="transactions"
         />
       </div>
+
       <div
         v-if="transactions && transactions.length >= 25"
         class="mx-5 sm:mx-10 mt-5 md:mt-10 flex flex-wrap"
@@ -170,3 +160,33 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.TransactionsNavigation {
+  @apply .flex .items-end .mb-8 .border-b;
+}
+
+.TransactionsNavigation--tab {
+  @apply .text-lg .text-theme-text-secondary .border-transparent .mr-4 .py-4 .px-2 .cursor-pointer .border-b-3;
+}
+
+.TransactionsNavigation--tab:hover {
+  @apply .text-theme-text-primary .border-blue;
+}
+
+.TransactionsNavigation--tab.active {
+  @apply .TransactionsNavigation--tab .text-2xl .border-blue .text-theme-text-primary;
+}
+
+.TransactionsNavigation--tab.disabled {
+  @apply .pointer-events-none .text-theme-text-tertiary
+}
+
+.TransactionsNavigation--tab > span {
+  @apply .text-xs .text-theme-text-tertiary;
+}
+
+.TransactionsNavigation--tab.active > span {
+  @apply .text-theme-text-secondary;
+}
+</style>

--- a/src/components/wallet/Transactions.vue
+++ b/src/components/wallet/Transactions.vue
@@ -175,7 +175,7 @@ export default {
 }
 
 .TransactionsNavigation--tab.active {
-  @apply .TransactionsNavigation--tab .text-2xl .border-blue .text-theme-text-primary;
+  @apply .text-2xl .border-blue .text-theme-text-primary;
 }
 
 .TransactionsNavigation--tab.disabled {

--- a/src/pages/Block/Transactions.vue
+++ b/src/pages/Block/Transactions.vue
@@ -66,7 +66,7 @@ export default {
       const { meta, data } = await TransactionService.byBlock(to.params.id, to.params.page)
 
       next(vm => {
-        vm.currentPage = to.params.page
+        vm.currentPage = Number(to.params.page)
         vm.setTransactions(data)
         vm.setMeta(meta)
       })
@@ -80,7 +80,7 @@ export default {
     try {
       const { meta, data } = await TransactionService.byBlock(to.params.id, to.params.page)
 
-      this.currentPage = to.params.page
+      this.currentPage = Number(to.params.page)
       this.setTransactions(data)
       this.setMeta(meta)
       next()

--- a/src/pages/TopWallets.vue
+++ b/src/pages/TopWallets.vue
@@ -69,7 +69,7 @@ export default {
       const { meta, data } = await WalletService.top(to.params.page)
 
       next(vm => {
-        vm.currentPage = to.params.page
+        vm.currentPage = Number(to.params.page)
         vm.setWallets(data)
         vm.setMeta(meta)
       })
@@ -83,7 +83,7 @@ export default {
     try {
       const { meta, data } = await WalletService.top(to.params.page)
 
-      this.currentPage = to.params.page
+      this.currentPage = Number(to.params.page)
       this.setWallets(data)
       this.setMeta(meta)
       next()

--- a/src/pages/Wallet/Blocks.vue
+++ b/src/pages/Wallet/Blocks.vue
@@ -89,7 +89,7 @@ export default {
       const { meta, data } = await BlockService.byAddress(to.params.address, to.params.page)
 
       next(vm => {
-        vm.currentPage = to.params.page
+        vm.currentPage = Number(to.params.page)
         vm.setBlocks(data)
         vm.setMeta(meta)
       })
@@ -103,7 +103,7 @@ export default {
     try {
       const { meta, data } = await BlockService.byAddress(to.params.address, to.params.page)
 
-      this.currentPage = to.params.page
+      this.currentPage = Number(to.params.page)
       this.setBlocks(data)
       this.setMeta(meta)
       next()

--- a/src/pages/Wallet/Transactions.vue
+++ b/src/pages/Wallet/Transactions.vue
@@ -48,7 +48,7 @@
             </span>
             <ul
               v-show="selectOpen"
-              class="absolute right-0 mt-px bg-white shadow rounded border overflow-hidden text-sm"
+              class="absolute right-0 mt-px bg-theme-content-background shadow-theme rounded border overflow-hidden text-sm"
             >
               <li
                 v-for="txType in ['all', 'sent', 'received']"

--- a/src/pages/Wallet/Transactions.vue
+++ b/src/pages/Wallet/Transactions.vue
@@ -137,7 +137,7 @@ export default {
       const { meta, data } = await TransactionService[`${to.params.type}ByAddress`](to.params.address, to.params.page)
 
       next(vm => {
-        vm.currentPage = to.params.page
+        vm.currentPage = Number(to.params.page)
         vm.setTransactions(data)
         vm.setMeta(meta)
       })
@@ -152,7 +152,7 @@ export default {
     try {
       const { meta, data } = await TransactionService[`${to.params.type}ByAddress`](to.params.address, to.params.page)
 
-      this.currentPage = to.params.page
+      this.currentPage = Number(to.params.page)
       this.setTransactions(data)
       this.setMeta(meta)
       next()

--- a/src/pages/Wallet/Voters.vue
+++ b/src/pages/Wallet/Voters.vue
@@ -72,7 +72,7 @@ export default {
       const { meta, data } = await DelegateService.voters(to.params.address, to.params.page)
 
       next(vm => {
-        vm.currentPage = to.params.page
+        vm.currentPage = Number(to.params.page)
         vm.setDelegate(delegate)
         vm.setWallets(data)
         vm.setMeta(meta)
@@ -88,7 +88,7 @@ export default {
       const delegate = await DelegateService.find(to.params.address)
       const { meta, data } = await DelegateService.voters(to.params.address, to.params.page)
 
-      this.currentPage = to.params.page
+      this.currentPage = Number(to.params.page)
       this.setDelegate(delegate)
       this.setWallets(data)
       this.setMeta(meta)

--- a/src/styles/_theme.css
+++ b/src/styles/_theme.css
@@ -49,8 +49,8 @@
   --color-theme-text-secondary: #a1a2a6;
   --color-theme-text-content: #a1a2a6;
   --color-theme-text-placeholder: #787a86;
-  --theme-shadow: none;
-  --theme-table-hover-shadow: none;
+  --theme-shadow: 0 1px 9px rgba(0, 0, 0, 0.15);
+  --theme-table-hover-shadow: 0 5px 30px rgba(0, 0, 0, 0.15);
   --theme-border: #25262c;
   --theme-border-secondary: #25262c;
   --nav-background: #2a2b31;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

This PR enables shadows when using the dark theme and styles the dropdowns accordingly.

It also:

- cleans up the wallet transactions component
- casts the page number to number type where it was not done yet
- adds a top padding to the market chart to avoid cropped hover circles

  ![image](https://user-images.githubusercontent.com/6547002/62871716-4a03ae80-bd1c-11e9-805c-0a8694190d79.png)


<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [x] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
