### PR TITLE
chore: improve gh pages script

### DIFF
--- a/build/webpack.prod.conf.js
+++ b/build/webpack.prod.conf.js
@@ -163,12 +163,7 @@ const createWebpackConfig = (baseUrl, network, networkConfig, routerMode) => {
 module.exports = (env) => {
   const args = argumentParser(env)
 
-  let baseUrl = args.baseUrl;
-  if (process.env.RELEASE_TYPE === "gh-pages") {
-    baseUrl = "/explorer/";
-  }
-
-  const webpackConfig = createWebpackConfig(baseUrl, args.network, args.networkConfig, args.routerMode)
+  const webpackConfig = createWebpackConfig(args.baseUrl, args.network, args.networkConfig, args.routerMode)
   webpackConfig.mode = 'production'
 
   if (config.build.productionGzip) {

--- a/config/index.js
+++ b/config/index.js
@@ -4,12 +4,6 @@
 
 const path = require('path')
 
-// Path used for building
-let assetsPublicPath = '/';
-if (process.env.RELEASE_TYPE === "gh-pages") {
-  assetsPublicPath = "/explorer/";
-}
-
 module.exports = {
   dev: {
     // Paths
@@ -55,7 +49,7 @@ module.exports = {
     // Paths
     assetsRoot: path.resolve(__dirname, '../dist'),
     assetsSubDirectory: 'static',
-    assetsPublicPath: assetsPublicPath,
+    assetsPublicPath: '/',
 
     /**
      * Source Maps

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,8 +4,7 @@
 set -e
 
 # build
-export RELEASE_TYPE="gh-pages"
-yarn build
+yarn build --base https://arkecosystem.github.io/explorer/
 
 # navigate into the build output directory
 cd dist

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -24,7 +24,6 @@ function getTitle (title) {
 
 const router = new Router({
   mode: process.env.ROUTER_MODE,
-  base: process.env.RELEASE_TYPE === 'gh-pages' ? '/explorer/' : '/',
   routes: [
     {
       path: '/',


### PR DESCRIPTION
Use the `base` parameter when building for gh pages instead of adjusting the webpack config to handle it.