### PR TITLE
fix: dynamic margins of pagination buttons

### DIFF
--- a/src/components/utils/pagination/Pagination.vue
+++ b/src/components/utils/pagination/Pagination.vue
@@ -23,7 +23,7 @@
     <div class="flex justify-center">
       <PaginationNavigationButton :is-visible="showFirst" type="first" class="mr-2" @click="emitFirst" />
 
-      <PaginationNavigationButton :is-visible="showPrevious" type="previous" class="mr-2" @click="emitPrevious" />
+      <PaginationNavigationButton :is-visible="showPrevious" type="previous" :class="{ 'no-margin': !showNext }" class="mr-2" @click="emitPrevious" />
 
       <div class="PaginationBar--large relative">
         <PaginationPageInput
@@ -62,7 +62,7 @@
         </div>
       </div>
 
-      <PaginationNavigationButton :is-visible="showNext" type="next" class="ml-2" @click="emitNext" />
+      <PaginationNavigationButton :is-visible="showNext" type="next" :class="{ 'no-margin': !showPrevious }" class="ml-2" @click="emitNext" />
 
       <PaginationNavigationButton :is-visible="showLast" type="last" class="ml-2" @click="emitLast" />
     </div>
@@ -250,6 +250,20 @@ button[class*="Pagination__Button--"] {
 
 .PaginationBar--large {
   @apply .hidden;
+}
+
+@media (max-width: 449px) {
+  .Pagination__Button--previous {
+    @apply .mr-1;
+  }
+
+  .Pagination__Button--next {
+    @apply .ml-1;
+  }
+
+  button[class*="Pagination__Button--"].no-margin {
+    @apply .mx-0;
+  }
 }
 
 @media (min-width: 450px) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

Fixes the margins of the pagination buttons on smaller screens.

![image](https://user-images.githubusercontent.com/6547002/67279110-a593aa80-f4ca-11e9-8a12-3eb37666b696.png)

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
