### PR TITLE
fix: add timelock status to detail screen and update multipayment table

### DIFF
--- a/__tests__/e2e/specs/wallet_spec.js
+++ b/__tests__/e2e/specs/wallet_spec.js
@@ -135,8 +135,7 @@ describe("Wallet", () => {
   it("should not show the container if the wallet is not voting", () => {
     cy.visit("wallets/AUDud8tvyVZa67p3QY7XPRUTjRGnWQQ9Xv");
 
-    cy.get(".WalletVote")
-      .should("not.exist")
+    cy.get(".WalletVote").should("not.exist");
   });
 
   it("should show delegate information", () => {

--- a/src/components/SelectionType.vue
+++ b/src/components/SelectionType.vue
@@ -80,12 +80,32 @@ export default class SelectionType extends Vue {
     { key: "TIMELOCK", type: CoreTransaction.TIMELOCK, typeGroup: TypeGroupTransaction.CORE },
     { key: "TIMELOCK_CLAIM", type: CoreTransaction.TIMELOCK_CLAIM, typeGroup: TypeGroupTransaction.CORE },
     { key: "TIMELOCK_REFUND", type: CoreTransaction.TIMELOCK_REFUND, typeGroup: TypeGroupTransaction.CORE },
-    { key: "BUSINESS_REGISTRATION", type: MagistrateTransaction.BUSINESS_REGISTRATION, typeGroup: TypeGroupTransaction.MAGISTRATE },
-    { key: "BUSINESS_RESIGNATION", type: MagistrateTransaction.BUSINESS_RESIGNATION, typeGroup: TypeGroupTransaction.MAGISTRATE },
+    {
+      key: "BUSINESS_REGISTRATION",
+      type: MagistrateTransaction.BUSINESS_REGISTRATION,
+      typeGroup: TypeGroupTransaction.MAGISTRATE,
+    },
+    {
+      key: "BUSINESS_RESIGNATION",
+      type: MagistrateTransaction.BUSINESS_RESIGNATION,
+      typeGroup: TypeGroupTransaction.MAGISTRATE,
+    },
     { key: "BUSINESS_UPDATE", type: MagistrateTransaction.BUSINESS_UPDATE, typeGroup: TypeGroupTransaction.MAGISTRATE },
-    { key: "BRIDGECHAIN_REGISTRATION", type: MagistrateTransaction.BRIDGECHAIN_REGISTRATION, typeGroup: TypeGroupTransaction.MAGISTRATE },
-    { key: "BRIDGECHAIN_RESIGNATION", type: MagistrateTransaction.BRIDGECHAIN_RESIGNATION, typeGroup: TypeGroupTransaction.MAGISTRATE },
-    { key: "BRIDGECHAIN_UPDATE", type: MagistrateTransaction.BRIDGECHAIN_UPDATE, typeGroup: TypeGroupTransaction.MAGISTRATE },
+    {
+      key: "BRIDGECHAIN_REGISTRATION",
+      type: MagistrateTransaction.BRIDGECHAIN_REGISTRATION,
+      typeGroup: TypeGroupTransaction.MAGISTRATE,
+    },
+    {
+      key: "BRIDGECHAIN_RESIGNATION",
+      type: MagistrateTransaction.BRIDGECHAIN_RESIGNATION,
+      typeGroup: TypeGroupTransaction.MAGISTRATE,
+    },
+    {
+      key: "BRIDGECHAIN_UPDATE",
+      type: MagistrateTransaction.BRIDGECHAIN_UPDATE,
+      typeGroup: TypeGroupTransaction.MAGISTRATE,
+    },
   ];
   private transactionType: ITransactionType = { key: "ALL", type: -1 };
   private selectOpen: boolean = false;

--- a/src/components/links/LinkWallet.vue
+++ b/src/components/links/LinkWallet.vue
@@ -44,9 +44,7 @@
         </RouterLink>
       </template>
 
-      <span v-else-if="type === coreTransaction.SECOND_SIGNATURE">{{
-        $t("TRANSACTION.TYPES.SECOND_SIGNATURE")
-      }}</span>
+      <span v-else-if="type === coreTransaction.SECOND_SIGNATURE">{{ $t("TRANSACTION.TYPES.SECOND_SIGNATURE") }}</span>
       <span v-else-if="type === coreTransaction.DELEGATE_REGISTRATION">{{
         $t("TRANSACTION.TYPES.DELEGATE_REGISTRATION")
       }}</span>

--- a/src/components/tables/mobile/Transactions.vue
+++ b/src/components/tables/mobile/Transactions.vue
@@ -51,7 +51,12 @@
             {{ $t("TRANSACTION.AMOUNT") }}
           </div>
           <div>
-            <TransactionAmount :transaction="transaction" :type="transaction.type" :type-group="transaction.typeGroup" tooltip-placement="left" />
+            <TransactionAmount
+              :transaction="transaction"
+              :type="transaction.type"
+              :type-group="transaction.typeGroup"
+              tooltip-placement="left"
+            />
           </div>
         </div>
 
@@ -60,7 +65,12 @@
             {{ $t("TRANSACTION.FEE") }}
           </div>
           <div>
-            <TransactionAmount :transaction="transaction" :is-fee="true" :type-group="transaction.typeGroup" tooltip-placement="left" />
+            <TransactionAmount
+              :transaction="transaction"
+              :is-fee="true"
+              :type-group="transaction.typeGroup"
+              tooltip-placement="left"
+            />
           </div>
         </div>
 
@@ -81,7 +91,7 @@
               v-tooltip="{
                 content: readableNumber(transaction.confirmations) + ' ' + $t('COMMON.CONFIRMATIONS'),
                 trigger: 'hover click',
-                placement: 'left'
+                placement: 'left',
               }"
             >
               {{ $t("TRANSACTION.WELL_CONFIRMED") }}

--- a/src/components/tables/mobile/TransactionsDetail.vue
+++ b/src/components/tables/mobile/TransactionsDetail.vue
@@ -49,7 +49,12 @@
             {{ $t("TRANSACTION.AMOUNT") }}
           </div>
           <div>
-            <TransactionAmount :transaction="transaction" :type="transaction.type" :type-group="transaction.typeGroup" tooltip-placement="left" />
+            <TransactionAmount
+              :transaction="transaction"
+              :type="transaction.type"
+              :type-group="transaction.typeGroup"
+              tooltip-placement="left"
+            />
           </div>
         </div>
 

--- a/src/components/utils/TransactionAmount.vue
+++ b/src/components/utils/TransactionAmount.vue
@@ -54,7 +54,10 @@ export default class TransactionAmount extends Vue {
 
   get isTransfer() {
     if (this.type !== undefined) {
-      return (this.type === CoreTransaction.TRANSFER || this.type === CoreTransaction.TIMELOCK) && this.typeGroup === TypeGroupTransaction.CORE;
+      return (
+        (this.type === CoreTransaction.TRANSFER || this.type === CoreTransaction.TIMELOCK) &&
+        this.typeGroup === TypeGroupTransaction.CORE
+      );
     }
     return false;
   }
@@ -62,8 +65,10 @@ export default class TransactionAmount extends Vue {
   get isOutgoing() {
     if (this.transaction.type === CoreTransaction.TIMELOCK && this.typeGroup === TypeGroupTransaction.CORE) {
       return (
-        (this.$route.params.address !== this.transaction.recipient && this.transaction.lockStatus === CoreTransaction.TIMELOCK_CLAIM) ||
-        (this.$route.params.address !== this.transaction.sender && this.transaction.lockStatus === CoreTransaction.TIMELOCK_REFUND)
+        (this.$route.params.address !== this.transaction.recipient &&
+          this.transaction.lockStatus === CoreTransaction.TIMELOCK_CLAIM) ||
+        (this.$route.params.address !== this.transaction.sender &&
+          this.transaction.lockStatus === CoreTransaction.TIMELOCK_REFUND)
       );
     }
     return this.transaction.sender === this.$route.params.address;
@@ -71,7 +76,10 @@ export default class TransactionAmount extends Vue {
 
   get isIncoming() {
     if (this.transaction.type === CoreTransaction.TIMELOCK && this.typeGroup === TypeGroupTransaction.CORE) {
-      return this.$route.params.address !== this.transaction.sender && this.transaction.lockStatus === CoreTransaction.TIMELOCK_CLAIM;
+      return (
+        this.$route.params.address !== this.transaction.sender &&
+        this.transaction.lockStatus === CoreTransaction.TIMELOCK_CLAIM
+      );
     }
     return this.transaction.recipient === this.$route.params.address && this.isTransfer;
   }

--- a/src/components/utils/pagination/Pagination.vue
+++ b/src/components/utils/pagination/Pagination.vue
@@ -23,7 +23,13 @@
     <div class="flex justify-center">
       <PaginationNavigationButton :is-visible="showFirst" type="first" class="mr-2" @click="emitFirst" />
 
-      <PaginationNavigationButton :is-visible="showPrevious" type="previous" :class="{ 'no-margin': !showNext }" class="mr-2" @click="emitPrevious" />
+      <PaginationNavigationButton
+        :is-visible="showPrevious"
+        type="previous"
+        :class="{ 'no-margin': !showNext }"
+        class="mr-2"
+        @click="emitPrevious"
+      />
 
       <div class="PaginationBar--large relative">
         <PaginationPageInput
@@ -62,7 +68,13 @@
         </div>
       </div>
 
-      <PaginationNavigationButton :is-visible="showNext" type="next" :class="{ 'no-margin': !showPrevious }" class="ml-2" @click="emitNext" />
+      <PaginationNavigationButton
+        :is-visible="showNext"
+        type="next"
+        :class="{ 'no-margin': !showPrevious }"
+        class="ml-2"
+        @click="emitNext"
+      />
 
       <PaginationNavigationButton :is-visible="showLast" type="last" class="ml-2" @click="emitLast" />
     </div>

--- a/src/components/wallet/Details.vue
+++ b/src/components/wallet/Details.vue
@@ -70,11 +70,7 @@
       <div v-if="view === 'public' && hasLockedBalance" class="flex-none border-r border-grey-dark px-9">
         <div class="flex items-center text-grey mb-2">
           {{ $t("WALLET.LOCKED_BALANCE") }}
-          <SvgIcon
-            class="ml-2"
-            name="locked-balance"
-            view-box="0 0 16 17"
-          />
+          <SvgIcon class="ml-2" name="locked-balance" view-box="0 0 16 17" />
         </div>
         <span
           v-tooltip="{
@@ -171,11 +167,7 @@
           <div v-if="view === 'public' && hasLockedBalance" class="md:w-1/2 px-6 w-full">
             <div class="flex items-center text-grey mb-2">
               {{ $t("WALLET.LOCKED_BALANCE") }}
-              <SvgIcon
-                class="ml-2"
-                name="locked-balance"
-                view-box="0 0 16 17"
-              />
+              <SvgIcon class="ml-2" name="locked-balance" view-box="0 0 16 17" />
             </div>
             <span
               v-tooltip="{

--- a/src/locales/en-GB.ts
+++ b/src/locales/en-GB.ts
@@ -64,7 +64,10 @@ export default {
       BLOCKHEIGHT: "Expiration blockheight",
       CLAIMED: "Claimed transaction",
       EXPIRATION: "Expiration",
+      OPEN: "Open lock",
       REFUND: "Refunded transaction",
+      STATUS: "Timelock status",
+      UNKNOWN: "Unknown",
     },
     TYPE: "Transaction type",
     TYPES: {
@@ -212,7 +215,7 @@ export default {
     DEVELOPMENT: "Development",
     SUPPLY: "Supply",
     MARKET_CAP: "Market Cap",
-    TESTNET: "Testnet Local"
+    TESTNET: "Testnet Local",
   },
 
   FOOTER: {

--- a/src/pages/Transaction.vue
+++ b/src/pages/Transaction.vue
@@ -38,10 +38,13 @@
 
       <TransactionDetails :transaction="transaction" ref="transactionDetails" />
 
-      <template v-if="transaction.type === coreTransaction.MULTI_PAYMENT && transaction.typeGroup === typeGroupTransaction.CORE">
+      <section
+        v-if="transaction.type === coreTransaction.MULTI_PAYMENT && transaction.typeGroup === typeGroupTransaction.CORE"
+        class="page-section py-5 md:py-10"
+      >
         <MultiPaymentTransactions :transaction="transaction" :page="currentPage" />
         <Pagination v-if="showPagination" :meta="meta" :current-page="currentPage" @page-change="onPageChange" />
-      </template>
+      </section>
     </template>
   </div>
 </template>
@@ -162,7 +165,11 @@ export default class TransactionPage extends Vue {
   }
 
   private calculateMeta() {
-    if (this.transaction && this.transaction.type === CoreTransaction.MULTI_PAYMENT && this.transaction.typeGroup === TypeGroupTransaction.CORE) {
+    if (
+      this.transaction &&
+      this.transaction.type === CoreTransaction.MULTI_PAYMENT &&
+      this.transaction.typeGroup === TypeGroupTransaction.CORE
+    ) {
       const transactions = this.transaction.asset.payments.length;
       const pages = Math.ceil(transactions / 25);
       this.meta = {


### PR DESCRIPTION
Adds a timelock status entry to the transaction detail screen; it will link to claimed / refunded timelocks or show `open` for timelocks that had no interaction yet.

Also adds a background to the multipayment table to be in line with the other tables in the explorer