### PR TITLE
feat: delegate pagination

### DIFF
--- a/__tests__/e2e/specs/delegate-monitor_spec.js
+++ b/__tests__/e2e/specs/delegate-monitor_spec.js
@@ -236,5 +236,15 @@ describe("Delegate Monitor", () => {
           cy.url().should("include", "wallets/");
         });
     });
+
+    it("should be possible to click the 'show more' button for active delegates", () => {
+      cy.get("h1")
+        .contains("Delegate Monitor")
+        .should("exist");
+
+      cy.url().should("include", "/delegate-monitor");
+      cy.get('button.button-lg').click();
+      cy.url().should("include", "delegates/");
+    });
   });
 });

--- a/__tests__/e2e/specs/delegates_spec.js
+++ b/__tests__/e2e/specs/delegates_spec.js
@@ -1,0 +1,75 @@
+describe("Delegates", () => {
+    it("should show 25 rows in the table", () => {
+      cy.visit("/delegates/1");
+      cy.get("table.vgt-table tbody tr").should('have.length', 25);
+    });
+
+    it("should be possible to sort the table", () => {
+      cy.get('div.max-w-2xl').then(($body) => {
+        if ($body.find('table').length) {
+          cy.get("th")
+            .eq(1)
+            .as("username")
+            .should("exist");
+          cy.get("@username")
+            .invoke("text")
+            .should("include", "Username");
+
+          cy.get("@username").should("not.have.class", "sorting-asc");
+          cy.get("@username").should("not.have.class", "sorting-desc");
+
+          cy.get("@username").click();
+          cy.get("@username").should("have.class", "sorting-asc");
+
+          cy.get("@username").click();
+          cy.get("@username").should("have.class", "sorting-desc");
+        }
+      });
+    });
+
+    it("should be possible to navigate to the next page and back", () => {
+      cy.get('div.max-w-2xl').then(($body) => {
+        if ($body.find('table').length) {
+          cy.get(".Pagination__Button--previous").should("not.exist");
+          cy.get(".Pagination__Button--next")
+            .should("exist")
+            .click();
+
+          cy.url().should("include", "delegates/2");
+
+          cy.get(".Pagination__Button--previous")
+            .should("exist")
+            .click();
+
+          cy.url().should("include", "delegates/1");
+        }
+      });
+    });
+
+    it("should be possible to click on a delegate username", () => {
+      cy.get('div.max-w-2xl').then(($body) => {
+        if ($body.find('table').length) {
+          cy.get("h1")
+            .contains("Delegates")
+            .should("exist")
+            .then($heading => {
+              const heading = $heading.text();
+
+              cy.get("tbody tr")
+                .first()
+                .within(() => {
+                  cy.get("a")
+                    .first()
+                    .click();
+                });
+
+              cy.get("h1").should($heading2 => {
+                expect($heading2.text()).not.to.eq(heading);
+              });
+
+              cy.url().should("include", "wallets/");
+            });
+        }
+      });
+    });
+  });

--- a/__tests__/unit/specs/services/delegate.spec.ts
+++ b/__tests__/unit/specs/services/delegate.spec.ts
@@ -35,15 +35,41 @@ describe("Services > Delegate", () => {
   });
 
   it("should return all available delegates", async () => {
-    const data = await DelegateService.all();
+    const data = await DelegateService.fetchEveryDelegate();
     expect(data.length).toBeGreaterThan(102);
     data.forEach(delegate => {
       expect(Object.keys(delegate).sort()).toEqual(delegatePropertyArray);
     });
   });
 
+  it("should return a list of delegates", async () => {
+    const { data } = await DelegateService.all();
+    expect(data).toHaveLength(25);
+    data.forEach(delegate => {
+      expect(Object.keys(delegate).sort()).toEqual(expect.arrayContaining(delegatePropertyArray));
+    });
+  });
+
+  it("should return delegates with page offset", async () => {
+    const { data } = await DelegateService.all(1);
+    expect(data).toHaveLength(25);
+    data.forEach(delegate => {
+      expect(Object.keys(delegate).sort()).toEqual(expect.arrayContaining(delegatePropertyArray));
+    });
+    expect(data.sort((a, b) => a.balance > b.balance)).toEqual(data);
+  });
+
+  it("should return delegates with page offset and given limit", async () => {
+    const { data } = await DelegateService.all(2, 20);
+    expect(data).toHaveLength(20);
+    data.forEach(delegate => {
+      expect(Object.keys(delegate).sort()).toEqual(expect.arrayContaining(delegatePropertyArray));
+    });
+    expect(data.sort((a, b) => a.balance > b.balance)).toEqual(data);
+  });
+
   it("should retrieve the voters based on given delegate address", async () => {
-    const { meta, data } = await DelegateService.voters("ARAq9nhjCxwpWnGKDgxveAJSijNG8Y6dFQ");
+    const { data } = await DelegateService.voters("ARAq9nhjCxwpWnGKDgxveAJSijNG8Y6dFQ");
     data.forEach(voter => {
       expect(Object.keys(voter).sort()).toEqual(expect.arrayContaining(voterPropertyArray));
     });
@@ -98,6 +124,17 @@ describe("Services > Delegate", () => {
 
     const data = await DelegateService.resigned();
     expect(data).toBeArray();
+    data.forEach(delegate => {
+      expect(Object.keys(delegate).sort()).toEqual(resignedDelegatePropertyArray);
+    });
+  });
+
+  it("should retrieve the resigned delegates", async () => {
+    // temporary set to devnet so the test passes
+    store.dispatch("network/setServer", "https://dexplorer.ark.io/api");
+
+    const { data } = await DelegateService.allResigned();
+    expect(data.length).toBeGreaterThan(0);
     data.forEach(delegate => {
       expect(Object.keys(delegate).sort()).toEqual(resignedDelegatePropertyArray);
     });

--- a/__tests__/unit/specs/services/delegate.spec.ts
+++ b/__tests__/unit/specs/services/delegate.spec.ts
@@ -81,6 +81,17 @@ describe("Services > Delegate", () => {
     ).rejects.toThrow();
   });
 
+  it("should retrieve the voterCount for a given public key", async () => {
+    const count = await DelegateService.voterCount("02b1d2ea7c265db66087789f571fceb8cc2b2d89e296ad966efb8ed51855f2ae0b", false);
+    expect(count).toBeGreaterThanOrEqual(0);
+  });
+
+  it("should be able to filter out low balance voters", async () => {
+    const count = await DelegateService.voterCount("02b1d2ea7c265db66087789f571fceb8cc2b2d89e296ad966efb8ed51855f2ae0b", false);
+    const countFiltered = await DelegateService.voterCount("02b1d2ea7c265db66087789f571fceb8cc2b2d89e296ad966efb8ed51855f2ae0b",);
+    expect(count).toBeGreaterThan(countFiltered);
+  });
+
   it("should return the delegate when searching by username", async () => {
     const data = await DelegateService.find("arkpool");
     expect(Object.keys(data).sort()).toEqual(delegatePropertyArray);

--- a/src/App.vue
+++ b/src/App.vue
@@ -150,7 +150,7 @@ export default class App extends Vue {
     const fetchedAt: number = parseInt(localStorage.getItem("delegatesFetchedAt") || "0", 10);
 
     if (!this.stateHasDelegates || !fetchedAt || this.updateRequired(fetchedAt)) {
-      const delegates = await DelegateService.all();
+      const delegates = await DelegateService.fetchEveryDelegate();
       this.$store.dispatch("delegates/setDelegates", {
         delegates,
         timestamp: Math.floor(Date.now() / 1000),

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -18,7 +18,7 @@ Vue.component("LinkTransaction", require("@/components/links/LinkTransaction").d
 Vue.component("LinkWallet", require("@/components/links/LinkWallet").default);
 
 // Tables
-Vue.component("TableDelegates", require("@/components/tables/Delegates").default);
+Vue.component("TableDelegates", require("@/components/tables/DelegateMonitor").default);
 Vue.component("MultiPaymentTransactions", require("@/components/tables/MultiPaymentTransactions").default);
 
 Vue.component("TableBlocksDesktop", require("@/components/tables/Blocks").default);
@@ -27,6 +27,7 @@ Vue.component("TableWalletsDesktop", require("@/components/tables/Wallets").defa
 Vue.component("TableLockTransactionsDesktop", require("@/components/tables/LockTransactions").default);
 Vue.component("TableBusinessesDesktop", require("@/components/tables/Businesses").default);
 Vue.component("TableBridgechainsDesktop", require("@/components/tables/Bridgechains").default);
+Vue.component("TableDelegatesDesktop", require("@/components/tables/Delegates").default);
 
 Vue.component("TableBlocksMobile", require("@/components/tables/mobile/Blocks").default);
 Vue.component("TableTransactionsMobile", require("@/components/tables/mobile/Transactions").default);

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -35,6 +35,7 @@ Vue.component("TableWalletsMobile", require("@/components/tables/mobile/Wallets"
 Vue.component("TableLockTransactionsMobile", require("@/components/tables/mobile/LockTransactions").default);
 Vue.component("TableBusinessesMobile", require("@/components/tables/mobile/Businesses").default);
 Vue.component("TableBridgechainsMobile", require("@/components/tables/mobile/Bridgechains").default);
+Vue.component("TableDelegatesMobile", require("@/components/tables/mobile/Delegates").default);
 
 // Misc.
 Vue.component("ArkMeter", require("@/components/monitor/ArkMeter").default);

--- a/src/components/tables/DelegateMonitor.vue
+++ b/src/components/tables/DelegateMonitor.vue
@@ -1,0 +1,198 @@
+<template>
+  <Loader :data="delegates">
+    <TableWrapper
+      v-bind="$attrs"
+      :columns="columns"
+      :rows="delegates"
+      :no-data-message="$t('COMMON.NO_RESULTS')"
+      @on-sort-change="emitSortChange"
+    >
+      <template slot-scope="data">
+        <div v-if="data.column.field === 'username'" class="flex items-center">
+          <LinkWallet :address="data.row.address">
+            {{ data.row.username }}
+          </LinkWallet>
+          <span v-if="isActiveTab && data.row.isResigned" class="ml-2 rounded text-sm text-white bg-theme-resigned-label p-1">{{
+            $t("WALLET.DELEGATE.STATUS.RESIGNED")
+          }}</span>
+        </div>
+
+        <div v-else-if="data.column.field === 'blocks.produced'">
+          {{ readableNumber(data.row.blocks.produced) }}
+        </div>
+
+        <div v-else-if="data.column.field === 'lastBlockHeight'">
+          {{ lastForgingTime(data.row) }}
+        </div>
+
+        <div v-else-if="data.column.field === 'forgingStatus'" class="text-0">
+          <button v-tooltip="statusTooltip(data.row)" role="img" :aria-label="tooltipContent(data.row)">
+            <SvgIcon
+              :class="`text-status-${status(data.row)}`"
+              class="mx-auto"
+              :name="status(data.row)"
+              view-box="0 0 19 17"
+            />
+          </button>
+        </div>
+
+        <div v-else-if="data.column.field === 'votes'">
+          <span v-tooltip="$t('COMMON.SUPPLY_PERCENTAGE')" class="text-grey text-2xs mr-1">
+            {{ percentageString(data.row.production.approval) }}
+          </span>
+          {{ readableCrypto(data.row.votes, true, 2) }}
+        </div>
+
+        <span v-else>
+          {{ data.formattedRow[data.column.field] }}
+        </span>
+      </template>
+    </TableWrapper>
+  </Loader>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from "vue-property-decorator";
+import { IDelegate, ISortParameters } from "@/interfaces";
+
+@Component
+export default class TableDelegates extends Vue {
+  @Prop({
+    required: true,
+    validator: value => {
+      return Array.isArray(value) || value === null;
+    },
+  })
+  public delegates: IDelegate[] | null;
+  @Prop({ required: false, default: "active" }) public activeTab: string;
+
+  get columns() {
+    let columns = [
+      {
+        label: this.$t("COMMON.RANK"),
+        field: "rank",
+        type: "number",
+        thClass: "start-cell w-32",
+        tdClass: "start-cell w-32",
+      },
+      {
+        label: this.$t("WALLET.DELEGATE.USERNAME"),
+        field: "username",
+        thClass: `text-left ${this.isActiveTab ? "end-cell sm:base-cell" : this.isResignedTab ? "start-cell" : ""}`,
+        tdClass: `text-left ${this.isActiveTab ? "end-cell sm:base-cell" : this.isResignedTab ? "start-cell" : ""}`,
+      },
+      {
+        label: this.$t("PAGES.DELEGATE_MONITOR.FORGED_BLOCKS"),
+        field: "blocks.produced",
+        type: "number",
+        thClass: "text-left hidden xl:table-cell",
+        tdClass: "text-left hidden xl:table-cell",
+      },
+      {
+        label: this.$t("PAGES.DELEGATE_MONITOR.LAST_FORGED"),
+        field: "lastBlockHeight",
+        type: "number",
+        sortFn: this.sortByLastBlockHeight,
+        thClass: "text-left hidden sm:table-cell",
+        tdClass: "text-left hidden sm:table-cell",
+      },
+      {
+        label: this.$t("PAGES.DELEGATE_MONITOR.STATUS.TITLE"),
+        field: "forgingStatus",
+        type: "number",
+        thClass: "end-cell md:base-cell text-center",
+        tdClass: "end-cell md:base-cell text-center",
+      },
+      {
+        label: this.$t("PAGES.DELEGATE_MONITOR.VOTES"),
+        field: "votes",
+        type: "number",
+        thClass: `end-cell hidden ${this.isActiveTab ? "md" : "sm"}:table-cell`,
+        tdClass: `end-cell hidden ${this.isActiveTab ? "md" : "sm"}:table-cell`,
+      },
+    ];
+
+    if (this.activeTab !== "active") {
+      // remove the columns for blocks, last forged and status
+      const index = columns.findIndex(el => {
+        return el.field === "blocks.produced";
+      });
+      columns.splice(index, 3);
+    }
+
+    if (this.activeTab === "resigned") {
+      // remove the rank column
+      columns = columns.splice(1);
+    }
+    return columns;
+  }
+
+  get isActiveTab() {
+    return this.activeTab === "active"
+  }
+
+  get isResignedTab() {
+    return this.activeTab === "resigned"
+  }
+
+  private lastForgingTime(delegate: IDelegate) {
+    return delegate.blocks.last
+      ? // Comment to keepe ts-ignore in check
+        // @ts-ignore
+        this.readableTimestampAgo(delegate.blocks.last.timestamp.unix)
+      : this.$i18n.t("PAGES.DELEGATE_MONITOR.NEVER");
+  }
+
+  private statusTooltip(row: any) {
+    return {
+      trigger: "hover click",
+      content: this.tooltipContent(row),
+      classes: [`tooltip-bg-${this.status(row)}`, "font-sans"],
+    };
+  }
+
+  private tooltipContent(row: any) {
+    // @ts-ignore
+    const status = {
+      0: this.$i18n.t("PAGES.DELEGATE_MONITOR.STATUS.FORGING"),
+      1: this.$i18n.t("PAGES.DELEGATE_MONITOR.STATUS.MISSING"),
+      2: this.$i18n.t("PAGES.DELEGATE_MONITOR.STATUS.NOT_FORGING"),
+      3: this.$i18n.t("PAGES.DELEGATE_MONITOR.STATUS.NEVER_FORGED"),
+      4: this.$i18n.t("PAGES.DELEGATE_MONITOR.STATUS.BECAME_ACTIVE"),
+    }[row.forgingStatus];
+
+    const lastBlock = row.blocks.last;
+
+    return lastBlock
+      ? `[${status}] ${this.$i18n.t("PAGES.DELEGATE_MONITOR.TOOLTIP", {
+          height: lastBlock.height,
+        })} ${
+          // @ts-ignore
+          this.readableTimestamp(lastBlock.timestamp.unix)
+        }`
+      : status;
+  }
+
+  private status(row: any) {
+    // @ts-ignore
+    return {
+      0: "forging",
+      1: "missed-round",
+      2: "not-forging",
+      3: "not-forging", // never-forged
+      4: "became-active",
+    }[row.forgingStatus];
+  }
+
+  private sortByLastBlockHeight(x: number, y: number, col: number, rowX: any, rowY: any) {
+    const heightX = rowX.blocks.last ? rowX.blocks.last.height : -1;
+    const heightY = rowY.blocks.last ? rowY.blocks.last.height : -1;
+
+    return heightX > heightY ? -1 : heightX < heightY ? 1 : 0;
+  }
+
+  private emitSortChange(params: ISortParameters[]) {
+    this.$emit("on-sort-change", params[0]);
+  }
+}
+</script>

--- a/src/components/tables/Delegates.vue
+++ b/src/components/tables/Delegates.vue
@@ -63,6 +63,7 @@ export default class TableDelegatesDesktop extends Vue {
         label: this.$t("COMMON.RANK"),
         field: "rank",
         type: "number",
+        sortFn: this.sortByRank,
         thClass: "start-cell w-32",
         tdClass: "start-cell w-32",
       },
@@ -99,6 +100,16 @@ export default class TableDelegatesDesktop extends Vue {
 
   private emitSortChange(params: ISortParameters[]) {
     this.$emit("on-sort-change", params[0]);
+  }
+
+  private sortByRank(x: number, y: number, col: number, rowX: any, rowY: any) {
+    if (x === null) {
+      return 1;
+    }
+    if (y === null) {
+      return -1;
+    }
+    return x < y ? 1 : -1;
   }
 }
 </script>

--- a/src/components/tables/Delegates.vue
+++ b/src/components/tables/Delegates.vue
@@ -55,21 +55,15 @@ export default class TableDelegatesDesktop extends Vue {
     },
   })
   public delegates: IDelegate[] | null;
+  @Prop({ required: false, default: false }) public hideRanks: boolean;
 
   get columns() {
     const columns = [
       {
-        label: this.$t("COMMON.RANK"),
-        field: "rank",
-        type: "number",
-        thClass: "start-cell w-32",
-        tdClass: "start-cell w-32",
-      },
-      {
         label: this.$t("WALLET.DELEGATE.USERNAME"),
         field: "username",
-        thClass: "text-left hidden md:table-cell",
-        tdClass: "text-left hidden md:table-cell",
+        thClass: this.usernameClass,
+        tdClass: this.usernameClass,
       },
       {
         label: this.$t("PAGES.DELEGATE_MONITOR.FORGED_BLOCKS"),
@@ -84,12 +78,28 @@ export default class TableDelegatesDesktop extends Vue {
       {
         label: this.$t("PAGES.DELEGATE_MONITOR.VOTES"),
         field: "votes",
+        type: "number",
         thClass: "end-cell hidden lg:table-cell",
         tdClass: "end-cell hidden lg:table-cell",
       },
     ];
+    if (!this.hideRanks) {
+      columns.unshift(
+        {
+          label: this.$t("COMMON.RANK"),
+          field: "rank",
+          type: "number",
+          thClass: "start-cell w-32",
+          tdClass: "start-cell w-32",
+        }
+      )
+    }
 
     return columns;
+  }
+
+  get usernameClass(): string {
+    return this.hideRanks ? "start-cell text-left" : "text-left";
   }
 
   private emitSortChange(params: ISortParameters[]) {

--- a/src/components/tables/Delegates.vue
+++ b/src/components/tables/Delegates.vue
@@ -8,11 +8,17 @@
       @on-sort-change="emitSortChange"
     >
       <template slot-scope="data">
-        <div v-if="data.column.field === 'username'" class="flex items-center">
+        <div v-if="data.column.field === 'rank'">
+          <span>
+            {{ data.row.rank }}
+          </span>
+        </div>
+
+        <div v-else-if="data.column.field === 'username'" class="flex items-center">
           <LinkWallet :address="data.row.address">
             {{ data.row.username }}
           </LinkWallet>
-          <span v-if="isActiveTab && data.row.isResigned" class="ml-2 rounded text-sm text-white bg-theme-resigned-label p-1">{{
+          <span v-if="data.row.isResigned" class="ml-2 rounded text-sm text-white bg-theme-resigned-label p-1">{{
             $t("WALLET.DELEGATE.STATUS.RESIGNED")
           }}</span>
         </div>
@@ -21,19 +27,8 @@
           {{ readableNumber(data.row.blocks.produced) }}
         </div>
 
-        <div v-else-if="data.column.field === 'lastBlockHeight'">
-          {{ lastForgingTime(data.row) }}
-        </div>
-
-        <div v-else-if="data.column.field === 'forgingStatus'" class="text-0">
-          <button v-tooltip="statusTooltip(data.row)" role="img" :aria-label="tooltipContent(data.row)">
-            <SvgIcon
-              :class="`text-status-${status(data.row)}`"
-              class="mx-auto"
-              :name="status(data.row)"
-              view-box="0 0 19 17"
-            />
-          </button>
+        <div v-else-if="data.column.field === 'forged.total'">
+          {{ readableCrypto(data.row.forged.total) }}
         </div>
 
         <div v-else-if="data.column.field === 'votes'">
@@ -42,21 +37,17 @@
           </span>
           {{ readableCrypto(data.row.votes, true, 2) }}
         </div>
-
-        <span v-else>
-          {{ data.formattedRow[data.column.field] }}
-        </span>
       </template>
     </TableWrapper>
   </Loader>
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from "vue-property-decorator";
+import { Component, Prop, Vue, Watch } from "vue-property-decorator";
 import { IDelegate, ISortParameters } from "@/interfaces";
 
 @Component
-export default class TableDelegates extends Vue {
+export default class TableDelegatesDesktop extends Vue {
   @Prop({
     required: true,
     validator: value => {
@@ -64,10 +55,9 @@ export default class TableDelegates extends Vue {
     },
   })
   public delegates: IDelegate[] | null;
-  @Prop({ required: false, default: "active" }) public activeTab: string;
 
   get columns() {
-    let columns = [
+    const columns = [
       {
         label: this.$t("COMMON.RANK"),
         field: "rank",
@@ -78,117 +68,28 @@ export default class TableDelegates extends Vue {
       {
         label: this.$t("WALLET.DELEGATE.USERNAME"),
         field: "username",
-        thClass: `text-left ${this.isActiveTab ? "end-cell sm:base-cell" : this.isResignedTab ? "start-cell" : ""}`,
-        tdClass: `text-left ${this.isActiveTab ? "end-cell sm:base-cell" : this.isResignedTab ? "start-cell" : ""}`,
+        thClass: "text-left hidden md:table-cell",
+        tdClass: "text-left hidden md:table-cell",
       },
       {
         label: this.$t("PAGES.DELEGATE_MONITOR.FORGED_BLOCKS"),
+        type: "number",
         field: "blocks.produced",
-        type: "number",
-        thClass: "text-left hidden xl:table-cell",
-        tdClass: "text-left hidden xl:table-cell",
       },
       {
-        label: this.$t("PAGES.DELEGATE_MONITOR.LAST_FORGED"),
-        field: "lastBlockHeight",
+        label: this.$t("WALLET.DELEGATE.TOTAL_FORGED"),
         type: "number",
-        sortFn: this.sortByLastBlockHeight,
-        thClass: "text-left hidden sm:table-cell",
-        tdClass: "text-left hidden sm:table-cell",
-      },
-      {
-        label: this.$t("PAGES.DELEGATE_MONITOR.STATUS.TITLE"),
-        field: "forgingStatus",
-        type: "number",
-        thClass: "end-cell md:base-cell text-center",
-        tdClass: "end-cell md:base-cell text-center",
+        field: "forged.total",
       },
       {
         label: this.$t("PAGES.DELEGATE_MONITOR.VOTES"),
         field: "votes",
-        type: "number",
-        thClass: `end-cell hidden ${this.isActiveTab ? "md" : "sm"}:table-cell`,
-        tdClass: `end-cell hidden ${this.isActiveTab ? "md" : "sm"}:table-cell`,
+        thClass: "end-cell hidden lg:table-cell",
+        tdClass: "end-cell hidden lg:table-cell",
       },
     ];
 
-    if (this.activeTab !== "active") {
-      // remove the columns for blocks, last forged and status
-      const index = columns.findIndex(el => {
-        return el.field === "blocks.produced";
-      });
-      columns.splice(index, 3);
-    }
-
-    if (this.activeTab === "resigned") {
-      // remove the rank column
-      columns = columns.splice(1);
-    }
     return columns;
-  }
-
-  get isActiveTab() {
-    return this.activeTab === "active"
-  }
-
-  get isResignedTab() {
-    return this.activeTab === "resigned"
-  }
-
-  private lastForgingTime(delegate: IDelegate) {
-    return delegate.blocks.last
-      ? // Comment to keepe ts-ignore in check
-        // @ts-ignore
-        this.readableTimestampAgo(delegate.blocks.last.timestamp.unix)
-      : this.$i18n.t("PAGES.DELEGATE_MONITOR.NEVER");
-  }
-
-  private statusTooltip(row: any) {
-    return {
-      trigger: "hover click",
-      content: this.tooltipContent(row),
-      classes: [`tooltip-bg-${this.status(row)}`, "font-sans"],
-    };
-  }
-
-  private tooltipContent(row: any) {
-    // @ts-ignore
-    const status = {
-      0: this.$i18n.t("PAGES.DELEGATE_MONITOR.STATUS.FORGING"),
-      1: this.$i18n.t("PAGES.DELEGATE_MONITOR.STATUS.MISSING"),
-      2: this.$i18n.t("PAGES.DELEGATE_MONITOR.STATUS.NOT_FORGING"),
-      3: this.$i18n.t("PAGES.DELEGATE_MONITOR.STATUS.NEVER_FORGED"),
-      4: this.$i18n.t("PAGES.DELEGATE_MONITOR.STATUS.BECAME_ACTIVE"),
-    }[row.forgingStatus];
-
-    const lastBlock = row.blocks.last;
-
-    return lastBlock
-      ? `[${status}] ${this.$i18n.t("PAGES.DELEGATE_MONITOR.TOOLTIP", {
-          height: lastBlock.height,
-        })} ${
-          // @ts-ignore
-          this.readableTimestamp(lastBlock.timestamp.unix)
-        }`
-      : status;
-  }
-
-  private status(row: any) {
-    // @ts-ignore
-    return {
-      0: "forging",
-      1: "missed-round",
-      2: "not-forging",
-      3: "not-forging", // never-forged
-      4: "became-active",
-    }[row.forgingStatus];
-  }
-
-  private sortByLastBlockHeight(x: number, y: number, col: number, rowX: any, rowY: any) {
-    const heightX = rowX.blocks.last ? rowX.blocks.last.height : -1;
-    const heightY = rowY.blocks.last ? rowY.blocks.last.height : -1;
-
-    return heightX > heightY ? -1 : heightX < heightY ? 1 : 0;
   }
 
   private emitSortChange(params: ISortParameters[]) {
@@ -196,3 +97,7 @@ export default class TableDelegates extends Vue {
   }
 }
 </script>
+
+<style>
+
+</style>

--- a/src/components/tables/Delegates.vue
+++ b/src/components/tables/Delegates.vue
@@ -58,12 +58,19 @@ export default class TableDelegatesDesktop extends Vue {
   @Prop({ required: false, default: false }) public hideRanks: boolean;
 
   get columns() {
-    const columns = [
+    let columns = [
+      {
+        label: this.$t("COMMON.RANK"),
+        field: "rank",
+        type: "number",
+        thClass: "start-cell w-32",
+        tdClass: "start-cell w-32",
+      },
       {
         label: this.$t("WALLET.DELEGATE.USERNAME"),
         field: "username",
-        thClass: this.usernameClass,
-        tdClass: this.usernameClass,
+        thClass: `${this.hideRanks ? "start-cell" : ""} text-left`,
+        tdClass: `${this.hideRanks ? "start-cell" : ""} text-left`,
       },
       {
         label: this.$t("PAGES.DELEGATE_MONITOR.FORGED_BLOCKS"),
@@ -83,23 +90,11 @@ export default class TableDelegatesDesktop extends Vue {
         tdClass: "end-cell hidden lg:table-cell",
       },
     ];
-    if (!this.hideRanks) {
-      columns.unshift(
-        {
-          label: this.$t("COMMON.RANK"),
-          field: "rank",
-          type: "number",
-          thClass: "start-cell w-32",
-          tdClass: "start-cell w-32",
-        }
-      )
+    if (this.hideRanks) {
+      columns = columns.splice(1);
     }
 
     return columns;
-  }
-
-  get usernameClass(): string {
-    return this.hideRanks ? "start-cell text-left" : "text-left";
   }
 
   private emitSortChange(params: ISortParameters[]) {

--- a/src/components/tables/mobile/Delegates.vue
+++ b/src/components/tables/mobile/Delegates.vue
@@ -1,0 +1,83 @@
+<template>
+  <div>
+    <Loader :data="delegates">
+      <div v-for="delegate in delegates" :key="delegate.address" class="row-mobile">
+        <div v-if="delegate.rank" class="list-row-border-b">
+          <div class="mr-4">
+            {{ $t("COMMON.RANK") }}
+          </div>
+          {{ delegate.rank }}
+        </div>
+
+        <div class="list-row-border-b">
+          <div class="mr-4">
+            {{ $t("WALLET.DELEGATE.USERNAME") }}
+          </div>
+          <div class="flex items-center">
+            <LinkWallet :address="delegate.address">
+                {{ delegate.username }}
+              </LinkWallet>
+              <span v-if="delegate.isResigned" class="ml-2 rounded text-sm text-white bg-theme-resigned-label p-1">{{
+                $t("WALLET.DELEGATE.STATUS.RESIGNED")
+              }}</span>
+          </div>
+        </div>
+
+        <div class="list-row-border-b">
+          <div class="mr-4">
+            {{ $t("PAGES.DELEGATE_MONITOR.FORGED_BLOCKS") }}
+          </div>
+          <div>
+            {{ readableNumber(delegate.blocks.produced) }}
+          </div>
+        </div>
+
+        <div class="list-row-border-b-no-wrap">
+          <div class="mr-4">
+            {{ $t("WALLET.DELEGATE.TOTAL_FORGED") }}
+          </div>
+          <div>
+            {{ readableCrypto(delegate.forged.total) }}
+          </div>
+        </div>
+
+        <div class="list-row">
+          <div class="mr-4">
+            {{ $t("PAGES.DELEGATE_MONITOR.VOTES") }}
+          </div>
+          <div>
+            <span v-tooltip="$t('COMMON.SUPPLY_PERCENTAGE')" class="text-grey text-2xs mr-1">
+              {{ percentageString(delegate.production.approval) }}
+            </span>
+            {{ readableCrypto(delegate.votes, true, 2) }}
+          </div>
+        </div>
+      </div>
+      <div v-if="delegates && !delegates.length" class="px-5 md:px-10">
+        <span>{{ $t("COMMON.NO_RESULTS") }}</span>
+      </div>
+    </Loader>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from "vue-property-decorator";
+import { IDelegate } from "@/interfaces";
+
+@Component
+export default class TableDelegatesMobile extends Vue {
+  @Prop({
+    required: true,
+    validator: value => {
+      return Array.isArray(value) || value === null;
+    },
+  })
+  public delegates: IDelegate[] | null;
+}
+</script>
+
+<style scoped>
+.row-mobile:nth-child(even) {
+  background-color: var(--color-theme-table-row);
+}
+</style>

--- a/src/locales/en-GB.ts
+++ b/src/locales/en-GB.ts
@@ -188,6 +188,9 @@ export default {
       WEBSITE: "Website",
       REPOSITORY: "Repository",
     },
+    DELEGATES: {
+      TITLE: "Delegates",
+    },
     DELEGATE_MONITOR: {
       TITLE: "Delegate Monitor",
       HEADER: {

--- a/src/pages/DelegateMonitor.vue
+++ b/src/pages/DelegateMonitor.vue
@@ -26,7 +26,7 @@
         @on-sort-change="onSortChange"
       />
 
-      <div v-if="delegates && delegates.length === 51" class="mx-5 sm:mx-10 mt-5 md:mt-10 flex flex-wrap">
+      <div v-if="delegates && delegates.length === activeDelegates" class="mx-5 sm:mx-10 mt-5 md:mt-10 flex flex-wrap">
         <RouterLink :to="{ name: activeTab === 'resigned' ? 'delegates-resigned' : 'delegates', params: { page: activeTab === 'standby' ? 5 : 3 } }" tag="button" class="button-lg">
           {{ $t("PAGINATION.SHOW_MORE") }}
         </RouterLink>
@@ -48,7 +48,7 @@ import DelegateService from "@/services/delegate";
     ForgingStats,
   },
   computed: {
-    ...mapGetters("network", ["height"]),
+    ...mapGetters("network", ["height", "activeDelegates"]),
   },
 })
 export default class DelegateMonitor extends Vue {

--- a/src/pages/DelegateMonitor.vue
+++ b/src/pages/DelegateMonitor.vue
@@ -25,6 +25,12 @@
         :sort-query="sortParams[activeTab]"
         @on-sort-change="onSortChange"
       />
+
+      <div v-if="delegates && delegates.length === 51" class="mx-5 sm:mx-10 mt-5 md:mt-10 flex flex-wrap">
+        <RouterLink :to="{ name: activeTab === 'resigned' ? 'delegates-resigned' : 'delegates', params: { page: activeTab === 'standby' ? 5 : 3 } }" tag="button" class="button-lg">
+          {{ $t("PAGINATION.SHOW_MORE") }}
+        </RouterLink>
+      </div>
     </section>
   </div>
 </template>

--- a/src/pages/Delegates.vue
+++ b/src/pages/Delegates.vue
@@ -56,7 +56,7 @@ export default class Delegates extends Vue {
   public async beforeRouteEnter(to: Route, from: Route, next: (vm?: any) => void) {
     try {
       const { meta, data } = to.name === "delegates-resigned" ?
-        await DelegateService.resigned(Number(to.params.page)) :
+        await DelegateService.allResigned(Number(to.params.page)) :
         await DelegateService.all(Number(to.params.page));
 
       next((vm: Delegates) => {
@@ -76,7 +76,7 @@ export default class Delegates extends Vue {
 
     try {
       const { meta, data } = to.name === "delegates-resigned" ?
-        await DelegateService.resigned(Number(to.params.page)) :
+        await DelegateService.allResigned(Number(to.params.page)) :
         await DelegateService.all(Number(to.params.page));
 
       this.resignedOnly = to.name === "delegates-resigned";

--- a/src/pages/Delegates.vue
+++ b/src/pages/Delegates.vue
@@ -5,7 +5,7 @@
       <div class="hidden sm:block">
         <TableDelegatesDesktop
           :delegates="delegates"
-          :sort-query="sortParams"
+          :sort-query="sortParams[resignedOnly ? 'tableResigned' : 'table']"
           :hide-ranks="resignedOnly"
           @on-sort-change="onSortChange"
         />
@@ -34,13 +34,16 @@ export default class Delegates extends Vue {
   }
 
   get sortParams() {
-    return this.$store.getters["ui/TODO"];
+    return this.$store.getters["ui/delegateSortParams"];
   }
 
   set sortParams(params: ISortParameters) {
-    this.$store.dispatch("ui/TODO", {
-      field: params.field,
-      type: params.type,
+    this.$store.dispatch("ui/setDelegateSortParams", {
+      ...this.sortParams,
+      [this.resignedOnly ? "tableResigned" : "table"]: {
+        field: params.field,
+        type: params.type,
+      },
     });
   }
   private delegates: IDelegate[] | null = null;

--- a/src/pages/Delegates.vue
+++ b/src/pages/Delegates.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="max-w-2xl mx-auto md:pt-5">
+    <ContentHeader>{{ $t("PAGES.DELEGATES.TITLE") }}</ContentHeader>
+    <section class="page-section py-5 md:py-10">
+      <div class="hidden sm:block">
+        <TableDelegatesDesktop
+          :delegates="delegates"
+          :sort-query="sortParams"
+          @on-sort-change="onSortChange"
+        />
+      </div>
+      <div class="sm:hidden">
+        <TableDelegatesDesktop :delegates="delegates" />
+      </div>
+      <Pagination v-if="showPagination" :meta="meta" :current-page="currentPage" @page-change="onPageChange" />
+    </section>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Watch } from "vue-property-decorator";
+import { mapGetters } from "vuex";
+import { Route } from "vue-router";
+import { ISortParameters, IDelegate } from "@/interfaces";
+import DelegateService from "@/services/delegate";
+
+Component.registerHooks(["beforeRouteEnter", "beforeRouteUpdate"]);
+
+@Component
+export default class Delegates extends Vue {
+  get showPagination() {
+    return this.meta && this.meta.pageCount > 1;
+  }
+
+  get sortParams() {
+    return this.$store.getters["ui/TODO"];
+  }
+
+  set sortParams(params: ISortParameters) {
+    this.$store.dispatch("ui/TODO", {
+      field: params.field,
+      type: params.type,
+    });
+  }
+  private delegates: IDelegate[] | null = null;
+  private meta: any | null = null;
+  private currentPage: number = 0;
+
+  @Watch("currentPage")
+  public onCurrentPageChanged() {
+    this.changePage();
+  }
+
+  public async beforeRouteEnter(to: Route, from: Route, next: (vm?: any) => void) {
+    try {
+      const { meta, data } = await DelegateService.all(Number(to.params.page));
+
+      next((vm: Delegates) => {
+        vm.currentPage = Number(to.params.page);
+        vm.setDelegates(data);
+        vm.setMeta(meta);
+      });
+    } catch (e) {
+      next({ name: "404" });
+    }
+  }
+
+  public async beforeRouteUpdate(to: Route, from: Route, next: (vm?: any) => void) {
+    this.delegates = null;
+    this.meta = null;
+
+    try {
+      const { meta, data } = await DelegateService.all(Number(to.params.page));
+
+      this.currentPage = Number(to.params.page);
+      this.setDelegates(data);
+      this.setMeta(meta);
+      next();
+    } catch (e) {
+      next({ name: "404" });
+    }
+  }
+
+  public setMeta(meta: any) {
+    this.meta = meta;
+  }
+
+  public onPageChange(page: number) {
+    this.currentPage = page;
+  }
+
+  public changePage() {
+    if (this.currentPage !== Number(this.$route.params.page)) {
+      // @ts-ignore
+      this.$router.push({
+        name: "delegates",
+        params: {
+          page: this.currentPage,
+        },
+      });
+    }
+  }
+
+  private setDelegates(delegates: IDelegate[]) {
+    this.delegates = delegates;
+  }
+
+  private onSortChange(params: ISortParameters) {
+    this.sortParams = params;
+  }
+}
+</script>

--- a/src/pages/Delegates.vue
+++ b/src/pages/Delegates.vue
@@ -11,7 +11,7 @@
         />
       </div>
       <div class="sm:hidden">
-        <TableDelegatesDesktop :delegates="delegates" />
+        <TableDelegatesMobile :delegates="delegates" />
       </div>
       <Pagination v-if="showPagination" :meta="meta" :current-page="currentPage" @page-change="onPageChange" />
     </section>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -24,6 +24,7 @@ const DelegateMonitorComponent = () => import(/* webpackChunkName: "delegate-mon
 const TopWalletsComponent = () => import(/* webpackChunkName: "top-wallets" */ "@/pages/TopWallets.vue");
 const BusinessesComponent = () => import(/* webpackChunkName: "businesses" */ "@/pages/Businesses.vue");
 const BridgechainsComponent = () => import(/* webpackChunkName: "bridgechains" */ "@/pages/Bridgechains.vue");
+const DelegateComponent = () => import(/* webpackChunkName: "delegates" */ "@/pages/Delegates.vue");
 const NotFoundComponent = () => import(/* webpackChunkName: "404" */ "@/pages/404.vue");
 
 Vue.use(Router);
@@ -183,6 +184,17 @@ const router = new Router({
       name: "bridgechains",
       component: BridgechainsComponent,
       meta: { title: (route: Route) => getTitle("Bridgechains") },
+    },
+    {
+      path: "/delegates",
+      redirect: to => ({ name: "delegates", params: { page: 1 } }),
+      meta: { title: (route: Route) => getTitle("Delegates") },
+    },
+    {
+      path: "/delegates/:page(\\d+)",
+      name: "delegates",
+      component: DelegateComponent,
+      meta: { title: (route: Route) => getTitle("Delegates") },
     },
     {
       path: "/404",

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -186,6 +186,17 @@ const router = new Router({
       meta: { title: (route: Route) => getTitle("Bridgechains") },
     },
     {
+      path: "/delegates/resigned",
+      redirect: to => ({ name: "delegates-resigned", params: { page: 1 } }),
+      meta: { title: (route: Route) => getTitle("Delegates") },
+    },
+    {
+      path: "/delegates/resigned/:page(\\d+)",
+      name: "delegates-resigned",
+      component: DelegateComponent,
+      meta: { title: (route: Route) => getTitle("Delegates") },
+    },
+    {
       path: "/delegates",
       redirect: to => ({ name: "delegates", params: { page: 1 } }),
       meta: { title: (route: Route) => getTitle("Delegates") },

--- a/src/services/delegate.ts
+++ b/src/services/delegate.ts
@@ -104,14 +104,16 @@ class DelegateService {
     return response.data;
   }
 
-  public async resigned(): Promise<IDelegate[]> {
+  public async resigned(page: number = 1, limit: number = 25): Promise<IApiDelegatesWrapper> {
     const response = (await ApiService.get("delegates", {
       params: {
         type: "resigned",
+        page,
+        limit,
       },
     })) as IApiDelegatesWrapper;
 
-    return response.data;
+    return response;
   }
 
   public async forged(): Promise<Array<{ delegate: string; forged: number }>> {

--- a/src/services/delegate.ts
+++ b/src/services/delegate.ts
@@ -104,7 +104,12 @@ class DelegateService {
     return response.data;
   }
 
-  public async resigned(page: number = 1, limit: number = 25): Promise<IApiDelegatesWrapper> {
+  public async resigned(): Promise<IDelegate[]> {
+    const response = await this.allResigned();
+    return response.data;
+  }
+
+  public async allResigned(page: number = 1, limit: number = 25): Promise<IApiDelegatesWrapper> {
     const response = (await ApiService.get("delegates", {
       params: {
         type: "resigned",

--- a/src/services/delegate.ts
+++ b/src/services/delegate.ts
@@ -4,7 +4,7 @@ import store from "@/store";
 import { IApiDelegateWrapper, IApiDelegatesWrapper, IApiDelegateVotersWrapper, IDelegate } from "../interfaces";
 
 class DelegateService {
-  public async all(): Promise<IDelegate[]> {
+  public async fetchEveryDelegate(): Promise<IDelegate[]> {
     const response = (await ApiService.get("delegates", {
       params: {
         page: 1,
@@ -26,6 +26,17 @@ class DelegateService {
     const results = await Promise.all(requests);
 
     return response.data.concat([].concat(...results.map(result => result.data)));
+  }
+
+  public async all(page: number = 1, limit: number = 25): Promise<IApiDelegatesWrapper> {
+    const response = (await ApiService.get("delegates", {
+      params: {
+        page,
+        limit,
+      },
+    })) as IApiDelegatesWrapper;
+
+    return response;
   }
 
   public async voters(query: string, page: number, limit = 25): Promise<IApiDelegateVotersWrapper> {

--- a/src/store/modules/ui.ts
+++ b/src/store/modules/ui.ts
@@ -241,6 +241,9 @@ const getters: GetterTree<IUiState, {}> = {
       : {
           active: { field: "rank", type: "asc" },
           standby: { field: "rank", type: "asc" },
+          resigned: { field: "votes", type: "asc" },
+          table: { field: "rank", type: "asc" },
+          tableResigned: { field: "votes", type: "asc" },
         };
   },
 


### PR DESCRIPTION
## Summary

Add pagination to the delegate monitor tables so we can see more than just the active / standby / first page of resigned delegates

Left todo:

- [x] update resigned delegate tab to work with the new API response structure
- [x] add mobile version of the table
- [x] improve the table checks for determining between regular / resigned delegates
- [x] think about making these pages fit 51 (depending on network) items per page to match the delegate monitor, or keep it at 25 and show e.g. 100-125 instead of 102-127 when clicking on `show more` on standby delegates
- [x] add `show more` button to standby / resigned delegates when applicable
- [x] add vuex store for the delegate table sorting options
- [x] unit & e2e tests

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
