### PR TITLE
refactor: make menu components dry

### DIFF
--- a/src/components/header/AppHeader.vue
+++ b/src/components/header/AppHeader.vue
@@ -12,7 +12,7 @@
       <HeaderCurrenciesDesktop v-else-if="headerType === 'currencies'" />
       <HeaderLanguagesDesktop v-else-if="headerType === 'languages'" />
       <HeaderDefault v-else />
-      <HeaderMenuDesktop v-if="menuVisible" />
+      <HeaderMenuDesktop v-if="menuVisible" :entries="menuEntries" />
     </div>
 
     <div class="w-full relative flex xl:hidden">
@@ -20,14 +20,14 @@
       <HeaderDefault v-else />
     </div>
 
-    <HeaderMenuMobile v-if="menuVisible" />
+    <HeaderMenuMobile v-if="menuVisible" :entries="menuEntries" />
     <HeaderCurrenciesMobile v-else-if="headerType === 'currencies'" />
     <HeaderLanguagesMobile v-else-if="headerType === 'languages'" />
   </header>
 </template>
 
 <script lang="ts">
-import { Component, Vue } from "vue-property-decorator";
+import { Component, Provide, Vue } from "vue-property-decorator";
 import { mapGetters } from "vuex";
 import {
   HeaderDefault,
@@ -53,11 +53,37 @@ import {
   },
   computed: {
     ...mapGetters("ui", ["headerType", "menuVisible"]),
+    ...mapGetters("network", ["hasMagistrateEnabled"]),
+
+    menuEntries() {
+      const entries = [
+        { name: "home" },
+        { name: "top-wallets", params: { page: 1 } },
+        { name: "delegate-monitor" },
+      ]
+
+      if (this.hasMagistrateEnabled) {
+        entries.push(
+          { name: "bridgechains", params: { page: 1 } },
+          { name: "businesses", params: { page: 1 } }
+        );
+      }
+
+      entries.push({ name: "advanced-search", params: { page: 1 } });
+
+      return entries;
+    }
   },
 })
 export default class AppHeader extends Vue {
+  @Provide("normalizeName") public foo = this.normalizeName;
+
   private headerType: string;
   private menuVisible: boolean;
+
+  public normalizeName(name: string): string {
+    return name.replace("-", "_").toUpperCase();
+  }
 
   private closeHeader(): void {
     this.$store.dispatch("ui/setHeaderType", null);

--- a/src/components/header/menu/Desktop.vue
+++ b/src/components/header/menu/Desktop.vue
@@ -7,50 +7,15 @@
       <SvgIcon class="flex-none" name="menu" view-box="0 0 15 13" />
     </button>
 
-    <RouterLink :to="{ name: 'home' }" tag="button" class="menu-button" @click.native="closeMenu">
-      {{ $t("PAGES.HOME.TITLE") }}
-    </RouterLink>
-
     <RouterLink
-      :to="{ name: 'top-wallets', params: { page: 1 } }"
+      v-for="entry in entries"
+      :key="entry.name"
+      :to="entry"
       tag="button"
       class="menu-button"
       @click.native="closeMenu"
     >
-      {{ $t("PAGES.TOP_WALLETS.TITLE") }}
-    </RouterLink>
-
-    <RouterLink :to="{ name: 'delegate-monitor' }" tag="button" class="menu-button" @click.native="closeMenu">
-      {{ $t("PAGES.DELEGATE_MONITOR.TITLE") }}
-    </RouterLink>
-
-    <RouterLink
-      v-if="hasMagistrateEnabled"
-      :to="{ name: 'bridgechains', params: { page: 1 } }"
-      tag="button"
-      class="menu-button"
-      @click.native="closeMenu"
-    >
-      {{ $t("PAGES.BRIDGECHAINS.TITLE") }}
-    </RouterLink>
-
-    <RouterLink
-      v-if="hasMagistrateEnabled"
-      :to="{ name: 'businesses', params: { page: 1 } }"
-      tag="button"
-      class="menu-button"
-      @click.native="closeMenu"
-    >
-      {{ $t("PAGES.BUSINESSES.TITLE") }}
-    </RouterLink>
-
-    <RouterLink
-      :to="{ name: 'advanced-search', params: { page: 1 } }"
-      tag="button"
-      class="menu-button"
-      @click.native="closeMenu"
-    >
-      {{ $t("PAGES.ADVANCED_SEARCH.TITLE") }}
+      {{ $t(`PAGES.${normalizeName(entry.name)}.TITLE`) }}
     </RouterLink>
 
     <div class="flex-auto" />
@@ -58,15 +23,15 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue } from "vue-property-decorator";
+import { Component, Inject, Prop, Vue } from "vue-property-decorator";
 import { mapGetters } from "vuex";
+import { Location } from "vue-router";
 
-@Component({
-  computed: {
-    ...mapGetters("network", ["hasMagistrateEnabled"]),
-  },
-})
+@Component({})
 export default class HeaderMenuDesktop extends Vue {
+  @Prop({ required: true }) public entries: Location[];
+  @Inject("normalizeName") public normalizeName: (name: string) => string;
+
   private closeMenu(): void {
     this.$store.dispatch("ui/setMenuVisible", false);
   }

--- a/src/components/header/menu/Mobile.vue
+++ b/src/components/header/menu/Mobile.vue
@@ -1,85 +1,51 @@
 <template>
-  <ul class="menu-container w-full max-w-480px bg-table-row absolute bottom-0 left-0 py-5 block xl:hidden">
-    <li :class="[nightMode ? 'hover:bg-grey-dark' : 'hover:bg-grey-light', 'flex justify-center']">
-      <RouterLink
-        :to="{ name: 'home' }"
-        tag="div"
-        class="cursor-pointer py-5 w-64 flex-none border-b border-theme-nav-border"
-      >
-        {{ $t("PAGES.HOME.TITLE") }}
-      </RouterLink>
-    </li>
-    <li :class="[nightMode ? 'hover:bg-grey-dark' : 'hover:bg-grey-light', 'flex justify-center']">
-      <RouterLink
-        :to="{ name: 'top-wallets', params: { page: 1 } }"
-        tag="div"
-        class="cursor-pointer py-5 w-64 flex-none border-b border-theme-nav-border"
-      >
-        {{ $t("PAGES.TOP_WALLETS.TITLE") }}
-      </RouterLink>
-    </li>
-    <li :class="[nightMode ? 'hover:bg-grey-dark' : 'hover:bg-grey-light', 'flex justify-center']">
-      <RouterLink
-        :to="{ name: 'delegate-monitor' }"
-        tag="div"
-        class="cursor-pointer py-5 w-64 flex-none border-b border-theme-nav-border"
-      >
-        {{ $t("PAGES.DELEGATE_MONITOR.TITLE") }}
-      </RouterLink>
-    </li>
+  <ul class="HeaderMenuMobile block xl:hidden">
     <li
-      v-if="hasMagistrateEnabled"
+      v-for="entry in entries"
+      :key="entry.name"
+      class="HeaderMenuMobile__Entry"
       :class="[nightMode ? 'hover:bg-grey-dark' : 'hover:bg-grey-light', 'flex justify-center']"
     >
       <RouterLink
-        :to="{ name: 'bridgechains', params: { page: 1 } }"
+        :to="entry"
         tag="div"
-        class="cursor-pointer py-5 w-64 flex-none border-b border-theme-nav-border"
+        class="HeaderMenuMobile__Entry__Link"
       >
-        {{ $t("PAGES.BRIDGECHAINS.TITLE") }}
-      </RouterLink>
-    </li>
-    <li
-      v-if="hasMagistrateEnabled"
-      :class="[nightMode ? 'hover:bg-grey-dark' : 'hover:bg-grey-light', 'flex justify-center']"
-    >
-      <RouterLink
-        :to="{ name: 'businesses', params: { page: 1 } }"
-        tag="div"
-        class="cursor-pointer py-5 w-64 flex-none border-b border-theme-nav-border"
-      >
-        {{ $t("PAGES.BUSINESSES.TITLE") }}
-      </RouterLink>
-    </li>
-    <li :class="[nightMode ? 'hover:bg-grey-dark' : 'hover:bg-grey-light', 'flex justify-center']">
-      <RouterLink
-        :to="{ name: 'advanced-search', params: { page: 1 }   }"
-        tag="div"
-        class="cursor-pointer py-5 w-64 flex-none"
-      >
-        {{ $t("PAGES.ADVANCED_SEARCH.TITLE") }}
+        {{ $t(`PAGES.${normalizeName(entry.name)}.TITLE`) }}
       </RouterLink>
     </li>
   </ul>
 </template>
 
 <script lang="ts">
-import { Component, Vue } from "vue-property-decorator";
+import { Component, Inject, Prop, Vue } from "vue-property-decorator";
 import { mapGetters } from "vuex";
+import { Location } from "vue-router";
 
 @Component({
   computed: {
     ...mapGetters("ui", ["nightMode"]),
-    ...mapGetters("network", ["hasMagistrateEnabled"]),
   },
 })
 export default class HeaderMenuMobile extends Vue {
+  @Prop({ required: true }) public entries: Location[];
+  @Inject("normalizeName") public normalizeName: (name: string) => string;
+
   private nightMode: boolean;
 }
 </script>
 
 <style>
-.menu-container {
+.HeaderMenuMobile {
   transform: translateY(100%);
+  @apply .w-full .max-w-480px .bg-table-row .absolute .bottom-0 .left-0 .py-5;
+}
+
+.HeaderMenuMobile__Entry .HeaderMenuMobile__Entry__Link {
+  @apply .cursor-pointer .py-5 .w-64 .flex-none .border-b .border-theme-nav-border;
+}
+
+.HeaderMenuMobile__Entry:last-of-type .HeaderMenuMobile__Entry__Link {
+  @apply .border-none;
 }
 </style>

--- a/src/components/header/menu/Mobile.vue
+++ b/src/components/header/menu/Mobile.vue
@@ -46,7 +46,7 @@
       <RouterLink
         :to="{ name: 'businesses', params: { page: 1 } }"
         tag="div"
-        class="cursor-pointer py-5 w-64 flex-none"
+        class="cursor-pointer py-5 w-64 flex-none border-b border-theme-nav-border"
       >
         {{ $t("PAGES.BUSINESSES.TITLE") }}
       </RouterLink>
@@ -55,7 +55,7 @@
       <RouterLink
         :to="{ name: 'advanced-search', params: { page: 1 }   }"
         tag="div"
-        class="cursor-pointer py-5 w-64 flex-none border-b border-theme-nav-border"
+        class="cursor-pointer py-5 w-64 flex-none"
       >
         {{ $t("PAGES.ADVANCED_SEARCH.TITLE") }}
       </RouterLink>

--- a/src/components/search/BlockSearchForm.vue
+++ b/src/components/search/BlockSearchForm.vue
@@ -4,13 +4,12 @@
 
     <div class="flex flex-wrap justify-between">
       <div class="flex w-full lg:w-1/3 mb-4 lg:mb-0">
-        <div class="w-1/2">
+        <div class="w-1/2 mr-3">
           <InputNumber
             @input="onInputChange"
             @keyup.enter.native="onEnterKey"
             :label="$t('PAGES.ADVANCED_SEARCH.BLOCK.TOTAL_AMOUNT_FROM')"
             name="totalAmount-from"
-            class="mr-3"
           />
         </div>
         <div class="w-1/2">
@@ -24,13 +23,12 @@
       </div>
 
       <div class="flex w-full lg:w-1/3 mb-4 lg:mb-0">
-        <div class="w-1/2">
+        <div class="w-1/2 mr-3">
           <InputNumber
             @input="onInputChange"
             @keyup.enter.native="onEnterKey"
             :label="$t('PAGES.ADVANCED_SEARCH.BLOCK.TOTAL_FEE_FROM')"
             name="totalFee-from"
-            class="mr-3"
           />
         </div>
         <div class="w-1/2">
@@ -44,11 +42,10 @@
       </div>
 
       <div class="flex w-full lg:w-auto mb-4 lg:mb-0">
-        <div class="w-1/2">
+        <div class="w-1/2 mr-3">
           <InputDate
             @input="onInputChange"
             @keyup.enter.native="onEnterKey"
-            class="mr-3"
             :label="$t('PAGES.ADVANCED_SEARCH.GENERIC.DATE_FROM')"
             name="timestamp-from"
           />

--- a/src/components/search/TransactionSearchForm.vue
+++ b/src/components/search/TransactionSearchForm.vue
@@ -15,11 +15,10 @@
       </div>
 
       <div class="flex w-full lg:w-56 mb-4 lg:mb-0">
-        <div class="w-1/2">
+        <div class="w-1/2 mr-3">
           <InputNumber
             @input="onInputChange"
             @keyup.enter.native="onEnterKey"
-            class="mr-3"
             :label="$t('PAGES.ADVANCED_SEARCH.TRANSACTION.AMOUNT_FROM')"
             name="amount-from"
             min="0"
@@ -37,11 +36,10 @@
       </div>
 
       <div class="flex w-full lg:w-56 mb-4 lg:mb-0">
-        <div class="w-1/2">
+        <div class="w-1/2 mr-3">
           <InputNumber
             @input="onInputChange"
             @keyup.enter.native="onEnterKey"
-            class="mr-3"
             :label="$t('PAGES.ADVANCED_SEARCH.TRANSACTION.FEE_FROM')"
             name="fee-from"
           />
@@ -57,11 +55,10 @@
       </div>
 
       <div class="flex w-full lg:w-auto mb-4 lg:mb-0">
-        <div class="w-1/2">
+        <div class="w-1/2 mr-3">
           <InputDate
             @input="onInputChange"
             @keyup.enter.native="onEnterKey"
-            class="mr-3"
             :label="$t('PAGES.ADVANCED_SEARCH.GENERIC.DATE_FROM')"
             name="timestamp-from"
           />

--- a/src/components/search/WalletSearchForm.vue
+++ b/src/components/search/WalletSearchForm.vue
@@ -22,11 +22,10 @@
       </div>
 
       <div class="flex w-full lg:w-auto">
-        <div class="w-1/2">
+        <div class="w-1/2 mr-3">
           <InputNumber
             @input="onInputChange"
             @keyup.enter.native="onEnterKey"
-            class="mr-3"
             :label="$t('PAGES.ADVANCED_SEARCH.WALLET.BALANCE_FROM')"
             name="balance-from"
             min="0"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

These changes reduce boilerplate in the menu components by providing the respective entries from the parent `AppHeader` component, which makes the addition or removal of any future menu entries more straightforward.

This PR also includes some small UI fixes:

- fixes the border on the "Advanced Search" menu entry on mobile views
- moves the margin of the half-width input fields to the parent container, so that both inputs actually have the same width

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
