### PR TITLE
fix: unicode representation

### DIFF
--- a/__tests__/unit/specs/mixins/crypto.spec.ts
+++ b/__tests__/unit/specs/mixins/crypto.spec.ts
@@ -1,0 +1,33 @@
+import { createLocalVue, shallowMount, Wrapper } from "@vue/test-utils";
+import CryptoMixin from "@/mixins/crypto";
+import store from "@/store";
+import Vue from "vue";
+
+describe("Mixins > Crypto", () => {
+  let wrapper: Wrapper<Vue>;
+
+  beforeEach(() => {
+    const localVue = createLocalVue();
+
+    const TestComponent = {
+      name: "TestComponent",
+      template: "<div />",
+    };
+
+    wrapper = shallowMount(TestComponent, {
+      localVue,
+      store,
+      mixins: [CryptoMixin],
+    });
+  });
+
+  describe("stringToHex", () => {
+    it("should change a string into its hex representation", () => {
+      expect(wrapper.vm.stringToHex("abcdefghijklmnopqrstuvwxyz")).toEqual("6162636465666768696a6b6c6d6e6f707172737475767778797a");
+      expect(wrapper.vm.stringToHex("this is some string")).toEqual("7468697320697320736f6d6520737472696e67");
+      expect(wrapper.vm.stringToHex("\u0011unicode\u0011works")).toEqual("11756e69636f646511776f726b73");
+      expect(wrapper.vm.stringToHex("18470234asdfa{}[];',./")).toEqual("313834373032333461736466617b7d5b5d3b272c2e2f");
+    });
+  });
+
+});

--- a/src/components/transaction/Details.vue
+++ b/src/components/transaction/Details.vue
@@ -87,8 +87,8 @@
 
         <div v-if="isTimelock(transaction.type, transaction.typeGroup)">
           <div class="list-row-border-b-no-wrap">
-            <div class="mr-4 whitespace-no-wrap">{{ $t("TRANSACTION.TIMELOCK.SECRET_HASH") }}</div>
-            <div class="overflow-hidden break-all">{{ transaction.asset.lock.secretHash }}</div>
+            <div class="mr-4 whitespace-no-wrap">{{ $t("TRANSACTION.TIMELOCK.SECRET_HASH_HEX") }}</div>
+            <div class="overflow-hidden break-all">{{ stringToHex(transaction.asset.lock.secretHash) }}</div>
           </div>
 
           <div v-if="transaction.asset.lock.expiration.type === 1" class="list-row-border-b">
@@ -120,7 +120,7 @@
         <div v-if="isTimelockClaim(transaction.type, transaction.typeGroup)">
           <div class="list-row-border-b-no-wrap">
             <div class="mr-4 whitespace-no-wrap">{{ $t("TRANSACTION.TIMELOCK.UNLOCK_SECRET_HEX") }}</div>
-            <div class="overflow-hidden break-all">{{ transaction.asset.claim.unlockSecret }}</div>
+            <div class="overflow-hidden break-all">{{ stringToHex(transaction.asset.claim.unlockSecret) }}</div>
           </div>
 
           <div class="list-row-border-b">

--- a/src/components/transaction/Details.vue
+++ b/src/components/transaction/Details.vue
@@ -86,9 +86,9 @@
         </div>
 
         <div v-if="isTimelock(transaction.type, transaction.typeGroup)">
-          <div class="list-row-border-b">
-            <div class="mr-4">{{ $t("TRANSACTION.TIMELOCK.SECRET_HASH") }}</div>
-            <div>{{ transaction.asset.lock.secretHash }}</div>
+          <div class="list-row-border-b-no-wrap">
+            <div class="mr-4 whitespace-no-wrap">{{ $t("TRANSACTION.TIMELOCK.SECRET_HASH") }}</div>
+            <div class="overflow-hidden break-all">{{ transaction.asset.lock.secretHash }}</div>
           </div>
 
           <div v-if="transaction.asset.lock.expiration.type === 1" class="list-row-border-b">
@@ -118,9 +118,9 @@
         </div>
 
         <div v-if="isTimelockClaim(transaction.type, transaction.typeGroup)">
-          <div class="list-row-border-b">
-            <div class="mr-4">{{ $t("TRANSACTION.TIMELOCK.UNLOCK_SECRET") }}</div>
-            <div>{{ transaction.asset.claim.unlockSecret }}</div>
+          <div class="list-row-border-b-no-wrap">
+            <div class="mr-4 whitespace-no-wrap">{{ $t("TRANSACTION.TIMELOCK.UNLOCK_SECRET_HEX") }}</div>
+            <div class="overflow-hidden break-all">{{ transaction.asset.claim.unlockSecret }}</div>
           </div>
 
           <div class="list-row-border-b">

--- a/src/components/transaction/Details.vue
+++ b/src/components/transaction/Details.vue
@@ -87,8 +87,8 @@
 
         <div v-if="isTimelock(transaction.type, transaction.typeGroup)">
           <div class="list-row-border-b-no-wrap">
-            <div class="mr-4 whitespace-no-wrap">{{ $t("TRANSACTION.TIMELOCK.SECRET_HASH_HEX") }}</div>
-            <div class="overflow-hidden break-all">{{ stringToHex(transaction.asset.lock.secretHash) }}</div>
+            <div class="mr-4 whitespace-no-wrap">{{ $t("TRANSACTION.TIMELOCK.SECRET_HASH") }}</div>
+            <div class="overflow-hidden break-all">{{ transaction.asset.lock.secretHash }}</div>
           </div>
 
           <div v-if="transaction.asset.lock.expiration.type === 1" class="list-row-border-b">

--- a/src/locales/en-GB.ts
+++ b/src/locales/en-GB.ts
@@ -78,7 +78,7 @@ export default {
       EXPIRATION: "Expiration",
       OPEN: "Open lock",
       REFUNDED: "Refunded transaction",
-      SECRET_HASH: "Secret Hash",
+      SECRET_HASH_HEX: "Secret Hash (hex)",
       STATUS: "Timelock status",
       UNKNOWN: "Unknown",
       UNLOCK_SECRET_HEX: "Unlock Secret (hex)",

--- a/src/locales/en-GB.ts
+++ b/src/locales/en-GB.ts
@@ -78,7 +78,7 @@ export default {
       EXPIRATION: "Expiration",
       OPEN: "Open lock",
       REFUNDED: "Refunded transaction",
-      SECRET_HASH_HEX: "Secret Hash (hex)",
+      SECRET_HASH: "Secret Hash",
       STATUS: "Timelock status",
       UNKNOWN: "Unknown",
       UNLOCK_SECRET_HEX: "Unlock Secret (hex)",

--- a/src/locales/en-GB.ts
+++ b/src/locales/en-GB.ts
@@ -81,7 +81,7 @@ export default {
       SECRET_HASH: "Secret Hash",
       STATUS: "Timelock status",
       UNKNOWN: "Unknown",
-      UNLOCK_SECRET: "Unlock Secret",
+      UNLOCK_SECRET_HEX: "Unlock Secret (hex)",
     },
     TYPE: "Transaction type",
     TYPES: {

--- a/src/mixins/crypto.ts
+++ b/src/mixins/crypto.ts
@@ -59,5 +59,9 @@ export default {
 
       return addressFromPublicKey(secp256k1.publicKeyCombine(keys, true).toString("hex"));
     },
+
+    stringToHex(text: string): string {
+      return Buffer.from(text).toString("hex");
+    }
   },
 };


### PR DESCRIPTION
Handle unicode representation in certain fields:

- [ ] ~smartbridge (stringify)~ see #820 
- [x] htlc secrets (hex)