### PR TITLE
refactor: remove invoke text calls

### DIFF
--- a/__tests__/e2e/specs/blocks_spec.js
+++ b/__tests__/e2e/specs/blocks_spec.js
@@ -13,8 +13,7 @@ describe("Blocks", () => {
       .as("id")
       .should("exist");
     cy.get("@id")
-      .invoke("text")
-      .should("include", "ID");
+      .should("contain.text", "ID");
 
     cy.get("@id").should("not.have.class", "sorting-asc");
     cy.get("@id").should("not.have.class", "sorting-desc");

--- a/__tests__/e2e/specs/bridgechains_spec.js
+++ b/__tests__/e2e/specs/bridgechains_spec.js
@@ -27,8 +27,7 @@ describe("Bridgechains", () => {
           .as("creator")
           .should("exist");
         cy.get("@creator")
-          .invoke("text")
-          .should("include", "Creator");
+          .should("contain.text", "Creator");
 
         cy.get("@creator").should("not.have.class", "sorting-asc");
         cy.get("@creator").should("not.have.class", "sorting-desc");

--- a/__tests__/e2e/specs/businesses_spec.js
+++ b/__tests__/e2e/specs/businesses_spec.js
@@ -27,8 +27,7 @@ describe("Businesses", () => {
           .as("creator")
           .should("exist");
         cy.get("@creator")
-          .invoke("text")
-          .should("include", "Creator");
+          .should("contain.text", "Creator");
 
         cy.get("@creator").should("not.have.class", "sorting-asc");
         cy.get("@creator").should("not.have.class", "sorting-desc");

--- a/__tests__/e2e/specs/delegate-monitor_spec.js
+++ b/__tests__/e2e/specs/delegate-monitor_spec.js
@@ -11,12 +11,10 @@ describe("Delegate Monitor", () => {
 
       cy.get("@divs")
         .eq(0)
-        .invoke("text")
-        .should("include", "Delegates");
+        .should("contain.text", "Delegates");
       cy.get("@divs")
         .eq(1)
-        .invoke("text")
-        .should("include", "Total forged");
+        .should("contain.text", "Total forged");
       cy.get("@divs")
         .eq(2)
         .invoke("text")
@@ -116,20 +114,16 @@ describe("Delegate Monitor", () => {
 
       cy.get("@fields")
         .eq(0)
-        .invoke("text")
-        .should("include", "Forged block recently");
+        .should("contain.text", "Forged block recently");
       cy.get("@fields")
         .eq(1)
-        .invoke("text")
-        .should("include", "Missed round");
+        .should("contain.text", "Missed round");
       cy.get("@fields")
         .eq(2)
-        .invoke("text")
-        .should("include", "Not forging");
+        .should("contain.text", "Not forging");
       cy.get("@fields")
         .eq(3)
-        .invoke("text")
-        .should("include", "In queue for forging");
+        .should("contain.text", "In queue for forging");
     });
 
     it("should be possible to sort the active delegates", () => {
@@ -138,8 +132,7 @@ describe("Delegate Monitor", () => {
         .as("name")
         .should("exist");
       cy.get("@name")
-        .invoke("text")
-        .should("include", "Username");
+        .should("contain.text", "Username");
 
       cy.get("@name").should("not.have.class", "sorting-asc");
       cy.get("@name").should("not.have.class", "sorting-desc");
@@ -201,8 +194,7 @@ describe("Delegate Monitor", () => {
         .as("name")
         .should("exist");
       cy.get("@name")
-        .invoke("text")
-        .should("include", "Username");
+        .should("contain.text", "Username");
 
       cy.get("@name").should("not.have.class", "sorting-asc");
       cy.get("@name").should("not.have.class", "sorting-desc");

--- a/__tests__/e2e/specs/delegates_spec.js
+++ b/__tests__/e2e/specs/delegates_spec.js
@@ -12,8 +12,7 @@ describe("Delegates", () => {
           .as("username")
           .should("exist");
         cy.get("@username")
-          .invoke("text")
-          .should("include", "Username");
+          .should("contain.text", "Username");
 
         cy.get("@username").should("not.have.class", "sorting-asc");
         cy.get("@username").should("not.have.class", "sorting-desc");

--- a/__tests__/e2e/specs/homepage_spec.js
+++ b/__tests__/e2e/specs/homepage_spec.js
@@ -12,20 +12,16 @@ describe("Homepage", () => {
 
     cy.get("@fields")
       .eq(0)
-      .invoke("text")
-      .should("include", "Height");
+      .should("contain.text", "Height");
     cy.get("@fields")
       .eq(1)
-      .invoke("text")
-      .should("include", "Network");
+      .should("contain.text", "Network");
     cy.get("@fields")
       .eq(2)
-      .invoke("text")
-      .should("include", "Supply");
+      .should("contain.text", "Supply");
     cy.get("@fields")
       .eq(3)
-      .invoke("text")
-      .should("include", "Market Cap");
+      .should("contain.text", "Market Cap");
 
     cy.get("#line-chart").should("be.visible");
     cy.get(".active-tab")
@@ -49,8 +45,7 @@ describe("Homepage", () => {
           .click();
         cy.get("span")
           .eq(1)
-          .invoke("text")
-          .should("include", "Vote");
+          .should("contain.text", "Vote");
       });
   });
 
@@ -163,8 +158,7 @@ describe("Homepage", () => {
           .click();
         cy.get("button.chart-tab-active")
           .first()
-          .invoke("text")
-          .should("include", "Volume");
+          .should("contain.text", "Volume");
       });
 
       cy.get("h1").then($heading => {
@@ -182,8 +176,7 @@ describe("Homepage", () => {
 
       cy.get("button.chart-tab-active")
         .first()
-        .invoke("text")
-        .should("include", "Volume");
+        .should("contain.text", "Volume");
     });
 
     it("should contain buttons for the period", () => {
@@ -194,8 +187,7 @@ describe("Homepage", () => {
           .each(($btn, index, $btns) => {
             cy.wrap($btn)
               .should("be.visible")
-              .invoke("text")
-              .should("include", buttons[index]);
+              .should("contain.text", buttons[index]);
           })
           .then($btns => {
             cy.wrap($btns).should("have.length", buttons.length);
@@ -239,8 +231,7 @@ describe("Homepage", () => {
       cy.get("#line-chart").should("be.visible");
 
       cy.get("button.chart-tab-active")
-        .invoke("text")
-        .should("include", "Year");
+        .should("contain.text", "Year");
     });
   });
 
@@ -481,8 +472,7 @@ describe("Homepage", () => {
         });
 
         cy.get("div.tooltip-inner")
-          .invoke("text")
-          .should("include", "Nothing matched your search");
+          .should("contain.text", "Nothing matched your search");
       });
     });
   });

--- a/__tests__/e2e/specs/top-wallets_spec.js
+++ b/__tests__/e2e/specs/top-wallets_spec.js
@@ -13,8 +13,7 @@ describe("Top Wallets", () => {
       .as("address")
       .should("exist");
     cy.get("@address")
-      .invoke("text")
-      .should("include", "Address");
+      .should("contain.text", "Address");
 
     cy.get("@address").should("not.have.class", "sorting-asc");
     cy.get("@address").should("not.have.class", "sorting-desc");

--- a/__tests__/e2e/specs/transactions_spec.js
+++ b/__tests__/e2e/specs/transactions_spec.js
@@ -13,8 +13,7 @@ describe("Transactions", () => {
       .as("id")
       .should("exist");
     cy.get("@id")
-      .invoke("text")
-      .should("include", "ID");
+      .should("contain.text", "ID");
 
     cy.get("@id").should("not.have.class", "sorting-asc");
     cy.get("@id").should("not.have.class", "sorting-desc");
@@ -136,8 +135,7 @@ describe("Transactions", () => {
         .click();
       cy.get("span")
         .last()
-        .invoke("text")
-        .should("include", "Vote");
+        .should("contain.text", "Vote");
     });
   });
 });

--- a/__tests__/e2e/specs/voters_spec.js
+++ b/__tests__/e2e/specs/voters_spec.js
@@ -13,8 +13,7 @@ describe("Voters", () => {
       .as("address")
       .should("exist");
     cy.get("@address")
-      .invoke("text")
-      .should("include", "Address");
+      .should("contain.text", "Address");
 
     cy.get("@address").should("not.have.class", "sorting-asc");
     cy.get("@address").should("not.have.class", "sorting-desc");
@@ -45,8 +44,7 @@ describe("Voters", () => {
     cy.visit("/wallets/ARAq9nhjCxwpWnGKDgxveAJSijNG8Y6dFQ/voters/1");
 
     cy.get("h1 span")
-      .invoke("text")
-      .should("include", "arkpool");
+      .should("contain.text", "arkpool");
   });
 
   it("should be possible to click on a wallet address", () => {
@@ -77,8 +75,7 @@ describe("Voters", () => {
   it("should redirect to 404 if the wallet address is invalid", () => {
     cy.visit("/wallets/ffffffffffffffffffffffffffffffffff/voters/1");
     cy.get("h1")
-      .invoke("text")
-      .should("include", "Ooops!");
+      .should("contain.text", "Ooops!");
     cy.url().should("include", "/404");
   });
 });

--- a/__tests__/e2e/specs/wallet_spec.js
+++ b/__tests__/e2e/specs/wallet_spec.js
@@ -96,8 +96,7 @@ describe("Wallet", () => {
         .click();
       cy.get("span")
         .last()
-        .invoke("text")
-        .should("include", "Received");
+        .should("contain.text", "Received");
     });
 
     cy.url().should("include", "wallets/AYCTHSZionfGoQsRnv5gECEuFWcZXS38gs/transactions/received/1");
@@ -213,8 +212,7 @@ describe("Wallet", () => {
     cy.visit("/wallets/ffffffffffffffffffffffffffffffffff");
 
     cy.get("h1")
-      .invoke("text")
-      .should("include", "Ooops!");
+      .should("contain.text", "Ooops!");
     cy.url().should("include", "/404");
   });
 });


### PR DESCRIPTION
Replace invoke("text").should("include",_) with should("contain.text",_)

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
