### PR TITLE
fix: default to address link

### DIFF
--- a/__tests__/unit/specs/components/links/LinkAddress.spec.ts
+++ b/__tests__/unit/specs/components/links/LinkAddress.spec.ts
@@ -1,0 +1,147 @@
+import { mount, createLocalVue, RouterLinkStub, Wrapper } from "@vue/test-utils";
+import StringsMixin from "@/mixins/strings";
+import TransactionTypesMixin from "@/mixins/transaction-types";
+import store from "@/store";
+import merge from "lodash/merge";
+
+import { LinkAddress } from "@/components/links";
+import SvgIcon from "@/components/SvgIcon";
+import { useI18n } from "../../../__utils__/i18n";
+
+describe("Components > Links > Wallet", () => {
+  let wrapper: Wrapper<Vue>;
+
+  const localVue = createLocalVue();
+  const i18n = useI18n(localVue);
+
+  const testAddress = "AUDud8tvyVZa67p3QY7XPRUTjRGnWQQ9Xv";
+  const testPublicKey = "021d03bace0687a1a5e797f884b13fb46f817ec32de1374a7f223f24404401d220";
+  const testDelegateAddress = "ALgvTAoz5Vi9easHqBK6aEMKatHb4beCXm";
+  const testDelegatePublicKey = "03aa4863c93d170d89675a6e381d08a451c1067fc0f6fed479571d9ecb178963b3";
+
+  const delegates = [{ username: "TestDelegate", address: testDelegateAddress, publicKey: testDelegatePublicKey }];
+
+  const mountComponent = config => {
+    return mount(
+      LinkAddress,
+      merge(
+        {
+          stubs: {
+            RouterLink: RouterLinkStub,
+            SvgIcon: "<svg></svg>",
+          },
+          i18n,
+          localVue,
+          mixins: [StringsMixin, TransactionTypesMixin],
+          store,
+        },
+        config,
+      ),
+    );
+  };
+
+  it("should display a full link to a wallet", () => {
+    wrapper = mountComponent({
+      propsData: {
+        address: testAddress,
+        publicKey: testPublicKey,
+        type: 0,
+        trunc: false,
+      },
+    });
+
+    expect(wrapper.contains("a")).toBe(true);
+    expect(wrapper.findAll("a")).toHaveLength(1);
+    expect(wrapper.text()).toEqual(expect.stringContaining(testAddress));
+    expect(wrapper.text()).toEqual(expect.stringContaining(wrapper.vm.truncate(testAddress)));
+  });
+
+  it("should display a truncated link to a wallet", () => {
+    wrapper = mountComponent({
+      propsData: {
+        address: testAddress,
+        publicKey: testPublicKey,
+        type: 0,
+      },
+    });
+
+    expect(wrapper.contains("a")).toBe(true);
+    expect(wrapper.findAll("a")).toHaveLength(1);
+    expect(wrapper.text()).not.toEqual(expect.stringContaining(testAddress));
+    expect(wrapper.text()).toEqual(expect.stringContaining(wrapper.vm.truncate(testAddress)));
+  });
+
+  it("should display the name of a known address", () => {
+    store.dispatch("network/setKnownWallets", { AUDud8tvyVZa67p3QY7XPRUTjRGnWQQ9Xv: "TestKnownWallet" });
+    wrapper = mountComponent({
+      propsData: {
+        address: testAddress,
+        publicKey: testPublicKey,
+        type: 0,
+      },
+    });
+
+    expect(wrapper.contains("a")).toBe(true);
+    expect(wrapper.findAll("a")).toHaveLength(1);
+    expect(wrapper.findAll("svg")).toHaveLength(1);
+    expect(wrapper.text()).not.toEqual(expect.stringContaining(testAddress));
+    expect(wrapper.text()).not.toEqual(expect.stringContaining(wrapper.vm.truncate(testAddress)));
+    expect(wrapper.text()).toEqual(expect.stringContaining("TestKnownWallet"));
+  });
+
+  it("should display the name of a delegate", done => {
+    store.dispatch("delegates/setDelegates", { delegates });
+    wrapper = mountComponent({
+      propsData: {
+        address: testDelegateAddress,
+        type: 0,
+      },
+    });
+
+    // Delegate name is set after function call in mounted(), so we need to wait a little while
+    expect(wrapper.contains("a")).toBe(true);
+    expect(wrapper.findAll("a")).toHaveLength(1);
+    setTimeout(() => {
+      expect(wrapper.text()).not.toEqual(expect.stringContaining(testDelegateAddress));
+      expect(wrapper.text()).not.toEqual(expect.stringContaining(wrapper.vm.truncate(testDelegateAddress)));
+      expect(wrapper.text()).toEqual(expect.stringContaining("TestDelegate"));
+      done();
+    }, 500);
+  });
+
+  it("should also find the delegate by public key", done => {
+    store.dispatch("delegates/setDelegates", { delegates });
+    wrapper = mountComponent({
+      propsData: {
+        publicKey: testDelegatePublicKey,
+        type: 0,
+      },
+    });
+
+    // Delegate name is set after function call in mounted(), so we need to wait a little while
+    expect(wrapper.contains("a")).toBe(true);
+    expect(wrapper.findAll("a")).toHaveLength(1);
+    setTimeout(() => {
+      expect(wrapper.text()).not.toEqual(expect.stringContaining(testDelegateAddress));
+      expect(wrapper.text()).not.toEqual(expect.stringContaining(wrapper.vm.truncate(testDelegateAddress)));
+      expect(wrapper.text()).toEqual(expect.stringContaining("TestDelegate"));
+      done();
+    }, 500);
+  });
+
+  it("should display Timelock recipient for type 8", () => {
+    wrapper = mountComponent({
+      propsData: {
+        address: testAddress,
+        type: 8
+      },
+    });
+
+    expect(wrapper.contains("a")).toBe(true);
+    expect(wrapper.findAll("a")).toHaveLength(1);
+    expect(wrapper.findAll("svg")).toHaveLength(1);
+    expect(wrapper.text()).not.toEqual(expect.stringContaining(testAddress));
+    expect(wrapper.text()).not.toEqual(expect.stringContaining(wrapper.vm.truncate(testAddress)));
+    expect(wrapper.text()).toEqual(expect.stringContaining("TestKnownWallet"));
+  });
+});

--- a/__tests__/unit/specs/components/links/LinkWallet.spec.ts
+++ b/__tests__/unit/specs/components/links/LinkWallet.spec.ts
@@ -179,5 +179,17 @@ describe("Components > Links > Wallet", () => {
       expect(wrapper.contains("a")).toBe(false);
       expect(wrapper.text()).toEqual(expect.stringContaining("Timelock Refund"));
     });
+
+    it("should use LinkAddress as fallback if unknown type is used", () => {
+      wrapper = mountComponent({
+        propsData: {
+          address: testAddress,
+          type: 12345,
+        },
+      });
+
+      expect(wrapper.contains("a")).toBe(true);
+      expect(wrapper.findAll("a")).toHaveLength(1);
+    });
   });
 });

--- a/__tests__/unit/specs/components/links/LinkWallet.spec.ts
+++ b/__tests__/unit/specs/components/links/LinkWallet.spec.ts
@@ -4,7 +4,7 @@ import TransactionTypesMixin from "@/mixins/transaction-types";
 import store from "@/store";
 import merge from "lodash/merge";
 
-import { LinkWallet } from "@/components/links";
+import { LinkWallet, LinkAddress } from "@/components/links";
 import SvgIcon from "@/components/SvgIcon";
 import { useI18n } from "../../../__utils__/i18n";
 
@@ -28,7 +28,8 @@ describe("Components > Links > Wallet", () => {
         {
           stubs: {
             RouterLink: RouterLinkStub,
-            SvgIcon: "<svg></svg>",
+            'SvgIcon': "<svg></svg>",
+            'LinkAddress': "<a>LinkAddress</a>"
           },
           i18n,
           localVue,
@@ -40,7 +41,7 @@ describe("Components > Links > Wallet", () => {
     );
   };
 
-  it("should display a full link to a wallet", () => {
+  it("should use LinkAddress for a transfer", () => {
     wrapper = mountComponent({
       propsData: {
         address: testAddress,
@@ -50,83 +51,10 @@ describe("Components > Links > Wallet", () => {
       },
     });
 
-    expect(wrapper.contains("a")).toBe(true);
-    expect(wrapper.findAll("a")).toHaveLength(1);
-    expect(wrapper.text()).toEqual(expect.stringContaining(testAddress));
-    expect(wrapper.text()).toEqual(expect.stringContaining(wrapper.vm.truncate(testAddress)));
-  });
-
-  it("should display a truncated link to a wallet", () => {
-    wrapper = mountComponent({
-      propsData: {
-        address: testAddress,
-        publicKey: testPublicKey,
-        type: 0,
-      },
-    });
+    console.log(wrapper.html())
 
     expect(wrapper.contains("a")).toBe(true);
     expect(wrapper.findAll("a")).toHaveLength(1);
-    expect(wrapper.text()).not.toEqual(expect.stringContaining(testAddress));
-    expect(wrapper.text()).toEqual(expect.stringContaining(wrapper.vm.truncate(testAddress)));
-  });
-
-  it("should display the name of a known address", () => {
-    store.dispatch("network/setKnownWallets", { AUDud8tvyVZa67p3QY7XPRUTjRGnWQQ9Xv: "TestKnownWallet" });
-    wrapper = mountComponent({
-      propsData: {
-        address: testAddress,
-        publicKey: testPublicKey,
-        type: 0,
-      },
-    });
-
-    expect(wrapper.contains("a")).toBe(true);
-    expect(wrapper.findAll("a")).toHaveLength(1);
-    expect(wrapper.findAll("svg")).toHaveLength(1);
-    expect(wrapper.text()).not.toEqual(expect.stringContaining(testAddress));
-    expect(wrapper.text()).not.toEqual(expect.stringContaining(wrapper.vm.truncate(testAddress)));
-    expect(wrapper.text()).toEqual(expect.stringContaining("TestKnownWallet"));
-  });
-
-  it("should display the name of a delegate", done => {
-    store.dispatch("delegates/setDelegates", { delegates });
-    wrapper = mountComponent({
-      propsData: {
-        address: testDelegateAddress,
-        type: 0,
-      },
-    });
-
-    // Delegate name is set after function call in mounted(), so we need to wait a little while
-    expect(wrapper.contains("a")).toBe(true);
-    expect(wrapper.findAll("a")).toHaveLength(1);
-    setTimeout(() => {
-      expect(wrapper.text()).not.toEqual(expect.stringContaining(testDelegateAddress));
-      expect(wrapper.text()).not.toEqual(expect.stringContaining(wrapper.vm.truncate(testDelegateAddress)));
-      expect(wrapper.text()).toEqual(expect.stringContaining("TestDelegate"));
-      done();
-    }, 500);
-  });
-
-  it("should also find the delegate by public key", done => {
-    store.dispatch("delegates/setDelegates", { delegates });
-    wrapper = mountComponent({
-      propsData: {
-        publicKey: testDelegatePublicKey,
-        type: 0,
-      },
-    });
-
-    // Delegate name is set after function call in mounted(), so we need to wait a little while
-    expect(wrapper.contains("a")).toBe(true);
-    expect(wrapper.findAll("a")).toHaveLength(1);
-    setTimeout(() => {
-      expect(wrapper.text()).not.toEqual(expect.stringContaining(testDelegateAddress));
-      expect(wrapper.text()).not.toEqual(expect.stringContaining(wrapper.vm.truncate(testDelegateAddress)));
-      expect(wrapper.text()).toEqual(expect.stringContaining("TestDelegate"));
-      done();
-    }, 500);
   });
 
   describe("When given a transaction type > 0", () => {
@@ -201,32 +129,39 @@ describe("Components > Links > Wallet", () => {
       expect(wrapper.text()).toEqual(expect.stringContaining("Delegate Resignation"));
     });
 
-    it("should display Timelock recipient for type 8", () => {
+    it("should use LinkAddress and icon for Timelock recipient for type 8 when instructed", () => {
       wrapper = mountComponent({
         propsData: {
           address: testAddress,
-          type: 8
+          type: 8,
+          showTimelockIcon: true,
         },
       });
 
       expect(wrapper.contains("a")).toBe(true);
       expect(wrapper.findAll("a")).toHaveLength(1);
       expect(wrapper.findAll("svg")).toHaveLength(1);
-      expect(wrapper.text()).not.toEqual(expect.stringContaining(testAddress));
-      expect(wrapper.text()).not.toEqual(expect.stringContaining(wrapper.vm.truncate(testAddress)));
-      expect(wrapper.text()).toEqual(expect.stringContaining("TestKnownWallet"));
+    });
+
+    it("should use LinkAddress without icon for Timelock recipient for type 8 otherwise", () => {
+      wrapper = mountComponent({
+        propsData: {
+          address: testAddress,
+          type: 8,
+        },
+      });
+
+      expect(wrapper.contains("a")).toBe(true);
+      expect(wrapper.findAll("a")).toHaveLength(1);
+      expect(wrapper.findAll("svg")).toHaveLength(0);
     });
 
     it("should display Timelock Claim for type 9", () => {
-      const wrapper = mount(LinkWallet, {
-        propsData: { type: 9 },
-        stubs: {
-          RouterLink: RouterLinkStub,
+      wrapper = mountComponent({
+        propsData: {
+          address: testAddress,
+          type: 9
         },
-        i18n,
-        localVue,
-        mixins: [StringsMixin, TransactionTypesMixin],
-        store,
       });
 
       expect(wrapper.contains("a")).toBe(false);
@@ -234,15 +169,11 @@ describe("Components > Links > Wallet", () => {
     });
 
     it("should display Timelock Refund for type 10", () => {
-      const wrapper = mount(LinkWallet, {
-        propsData: { type: 10 },
-        stubs: {
-          RouterLink: RouterLinkStub,
+      wrapper = mountComponent({
+        propsData: {
+          address: testAddress,
+          type: 10
         },
-        i18n,
-        localVue,
-        mixins: [StringsMixin, TransactionTypesMixin],
-        store,
       });
 
       expect(wrapper.contains("a")).toBe(false);

--- a/src/components/links/LinkAddress.vue
+++ b/src/components/links/LinkAddress.vue
@@ -88,6 +88,10 @@ export default class LinkAddress extends Vue {
     this.determine();
   }
 
+  public mounted(): void {
+    this.determine();
+  }
+
   private determine(): void {
     this.address ? this.findByAddress() : this.findByPublicKey();
   }
@@ -100,7 +104,7 @@ export default class LinkAddress extends Vue {
     this.delegate = this.delegates.find(d => d.publicKey === this.publicKey);
   }
 
-  private getAddress(): string | false {
+  private getAddress(): string | boolean {
     const knownOrDelegate = this.isKnown || this.delegate;
     const truncated = !this.hasDefaultSlot && this.trunc;
 

--- a/src/components/links/LinkAddress.vue
+++ b/src/components/links/LinkAddress.vue
@@ -1,0 +1,114 @@
+<template>
+  <div :class="containerClass">
+    <RouterLink v-if="isKnown" :to="{ name: 'wallet', params: { address: walletAddress } }" class="flex items-center">
+      <span
+        v-tooltip="{
+          content: getAddress(),
+          placement: tooltipPlacement,
+        }"
+      >
+        {{ knownWallets[address] }}
+      </span>
+      <SvgIcon
+        v-tooltip="{
+          content: $t('WALLET.VERIFIED'),
+          placement: tooltipPlacement,
+        }"
+        class="flex flex-none ml-2"
+        name="verified"
+        view-box="0 0 16 17"
+      />
+    </RouterLink>
+    <RouterLink
+      v-else
+      v-tooltip="{
+        content: getAddress(),
+        placement: tooltipPlacement,
+      }"
+      :to="{ name: 'wallet', params: { address: walletAddress } }"
+    >
+      <span v-if="hasDefaultSlot">
+        <slot />
+      </span>
+      <span v-else-if="delegate">{{ delegate.username }}</span>
+      <span v-else-if="address">
+        <span class="hidden md:inline-block">{{ trunc ? truncate(address) : address }}</span>
+        <span class="md:hidden">{{ truncate(address) }}</span>
+      </span>
+    </RouterLink>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue, Watch } from "vue-property-decorator";
+import { mapGetters } from "vuex";
+import { IDelegate } from "@/interfaces";
+
+@Component({
+  computed: {
+    ...mapGetters("delegates", ["delegates"]),
+    ...mapGetters("network", ["knownWallets"]),
+  },
+})
+export default class LinkAddress extends Vue {
+  @Prop({ required: false, default: "" }) public address: string;
+  @Prop({ required: false, default: "" }) public publicKey: string;
+  @Prop({ required: false, default: true }) public trunc: boolean;
+  @Prop({ required: false, default: "top" }) public tooltipPlacement: string;
+  @Prop({ required: false, default: "" }) public containerClass: string;
+
+  private delegate: IDelegate | null | undefined = null;
+  private delegates: IDelegate[];
+  private knownWallets: { [key: string]: string };
+
+  get isKnown(): string {
+    return this.knownWallets[this.address];
+  }
+
+  get hasDefaultSlot(): boolean {
+    return !!this.$slots.default;
+  }
+
+  get walletAddress(): string {
+    return this.delegate ? this.delegate.address : this.address;
+  }
+
+  @Watch("delegates")
+  public onDelegateChanged() {
+    this.determine();
+  }
+
+  @Watch("address")
+  public onAddressChanged() {
+    this.determine();
+  }
+
+  @Watch("publicKey")
+  public onPublicKeyChanged() {
+    this.determine();
+  }
+
+  private determine(): void {
+    this.address ? this.findByAddress() : this.findByPublicKey();
+  }
+
+  private findByAddress(): void {
+    this.delegate = this.delegates.find(d => d.address === this.address);
+  }
+
+  private findByPublicKey(): void {
+    this.delegate = this.delegates.find(d => d.publicKey === this.publicKey);
+  }
+
+  private getAddress(): string | false {
+    const knownOrDelegate = this.isKnown || this.delegate;
+    const truncated = !this.hasDefaultSlot && this.trunc;
+
+    if (knownOrDelegate || truncated) {
+      return this.walletAddress;
+    }
+
+    return false;
+  }
+}
+</script>

--- a/src/components/links/LinkWallet.vue
+++ b/src/components/links/LinkWallet.vue
@@ -130,7 +130,7 @@ export default class LinkWallet extends Vue {
     return this.votedDelegate ? this.votedDelegate.username : "";
   }
 
-  get multiPaymentRecipientsCount() {
+  get multiPaymentRecipientsCount(): number {
     if (this.asset && this.asset.payments) {
       return this.asset.payments.length;
     }

--- a/src/components/links/index.ts
+++ b/src/components/links/index.ts
@@ -1,5 +1,6 @@
 import LinkBlock from "./LinkBlock.vue";
 import LinkTransaction from "./LinkTransaction.vue";
 import LinkWallet from "./LinkWallet.vue";
+import LinkAddress from "./LinkAddress.vue";
 
-export { LinkBlock, LinkTransaction, LinkWallet };
+export { LinkBlock, LinkTransaction, LinkWallet, LinkAddress };

--- a/src/components/transaction/Details.vue
+++ b/src/components/transaction/Details.vue
@@ -18,15 +18,14 @@
 
         <div class="list-row-border-b">
           <div class="mr-4">{{ $t("TRANSACTION.TYPE") }}</div>
-          <span v-if="isTransfer(transaction.type, transaction.typeGroup)">{{ $t("TRANSACTION.TYPES.TRANSFER") }}</span>
-          <span v-else-if="isTimelock(transaction.type, transaction.typeGroup)">{{ $t("TRANSACTION.TYPES.TIMELOCK_CLAIM") }}</span>
-          <div v-else class="truncate">
+          <div class="truncate">
             <LinkWallet
               :address="transaction.recipient"
               :type="transaction.type"
               :asset="transaction.asset"
               :trunc="false"
               :type-group="transaction.typeGroup"
+              :showAsType="true"
               tooltip-placement="left"
             />
           </div>

--- a/src/locales/en-GB.ts
+++ b/src/locales/en-GB.ts
@@ -107,6 +107,7 @@ export default {
       BRIDGECHAIN_UPDATE: "Bridgechain Update",
       SENT: "Sent",
       RECEIVED: "Received",
+      UNKNOWN: "Unknown",
     },
     ASSET: {
       BRIDGECHAINID: "Bridgechain ID",


### PR DESCRIPTION
When an unknown type / typegroup combination was given, `LinkWallet` would display nothing at all. This refactors the `LinkWallet` component to default to showing the address / public key that was given when nothing matches. Also a small code refactor so we don't end up with duplicate code in `LinkWallet` to accommodate for the default case.

Resolves #823 