### PR TITLE
fix: sort by rank order on delegates table

### DIFF
--- a/src/components/tables/Delegates.vue
+++ b/src/components/tables/Delegates.vue
@@ -102,14 +102,14 @@ export default class TableDelegatesDesktop extends Vue {
     this.$emit("on-sort-change", params[0]);
   }
 
-  private sortByRank(x: number, y: number, col: number, rowX: any, rowY: any) {
+  private sortByRank(x: number, y: number) {
     if (x === null) {
       return 1;
     }
     if (y === null) {
       return -1;
     }
-    return x < y ? 1 : -1;
+    return x < y ? -1 : 1;
   }
 }
 </script>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Small fix for the sorting order of the rank on the delegate table, where it is currently inverted.

![image](https://user-images.githubusercontent.com/6547002/74133447-e1bd5900-4be8-11ea-8e23-cd070db7336e.png)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
