### PR TITLE
fix: remove border on last transaction asset property

### DIFF
--- a/src/components/transaction/Details.vue
+++ b/src/components/transaction/Details.vue
@@ -209,7 +209,11 @@
       class="page-section py-5 md:py-10 mb-5"
     >
       <div class="px-5 sm:px-10">
-        <div v-for="(value, prop, index) in assetField" :key="prop" :class="index === Object.keys(assetField).length - 1 ? 'list-row' : 'list-row-border-b'">
+        <div
+          v-for="(value, prop, index) in assetField"
+          :key="prop"
+          :class="index === Object.keys(assetField).length - 1 ? 'list-row' : 'list-row-border-b'"
+        >
           <div class="mr-4">{{ $t(`TRANSACTION.ASSET.${prop.toUpperCase()}`) }}</div>
           <div class="overflow-hidden break-all">{{ value }}</div>
         </div>

--- a/src/components/transaction/Details.vue
+++ b/src/components/transaction/Details.vue
@@ -209,7 +209,7 @@
       class="page-section py-5 md:py-10 mb-5"
     >
       <div class="px-5 sm:px-10">
-        <div v-for="(value, prop) in assetField" :key="prop" class="list-row-border-b">
+        <div v-for="(value, prop, index) in assetField" :key="prop" :class="index === Object.keys(assetField).length - 1 ? 'list-row' : 'list-row-border-b'">
           <div class="mr-4">{{ $t(`TRANSACTION.ASSET.${prop.toUpperCase()}`) }}</div>
           <div class="overflow-hidden break-all">{{ value }}</div>
         </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Do not set border on the last row of the magistrate asset details.

![image](https://user-images.githubusercontent.com/6547002/75381921-e87ee800-58d9-11ea-8ad4-c96a6af8d465.png)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
