### PR TITLE
fix: do not censor floats in vendorfield

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        env:
+          GIT_TRACE: 1
+          GIT_CURL_VERBOSE: 1
         with:
           ref: ${{ github.head_ref }}
 

--- a/src/utils/Sanitizer.ts
+++ b/src/utils/Sanitizer.ts
@@ -682,6 +682,7 @@ export class Sanitizer {
   private removeSpam(value: string): string {
     const censorify = new Censorify();
     const exceptions = [
+      new RegExp(/[+-]?\d+(\.\d+)/g),
       (match) => match.url === "http://dpos.arky-delegate.info",
       (match) => match.url === "http://arky-delegate.info",
       (match) => match.url === "https://arkfun.io/",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Floats in a vendorfield are recognized as urls by the sanitizer and thus censored, e.g. https://dexplorer.ark.io/transaction/fe9150ed52b3dd693df8f38f443c0984e4b5baf65bfda694cf6a5d656911dd1a

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
