### PR TITLE
test: adds 100% coverage for component wallet/Delegate.vue

### DIFF
--- a/__tests__/unit/specs/components/wallet/Delegate.spec.ts
+++ b/__tests__/unit/specs/components/wallet/Delegate.spec.ts
@@ -1,16 +1,17 @@
 import { mount, createLocalVue, RouterLinkStub } from "@vue/test-utils";
 import mixins from "@/mixins";
+import merge from "lodash/merge"
 
 import WalletDelegate from "@/components/wallet/Delegate";
 import { useI18n } from "../../../__utils__/i18n";
 import Vuex from "vuex";
 
-describe("Components > Wallet > Delegate", () => {
-  const localVue = createLocalVue();
-  localVue.use(Vuex);
+const localVue = createLocalVue();
+localVue.use(Vuex);
 
-  const i18n = useI18n(localVue);
+const i18n = useI18n(localVue);
 
+const mountComponent = config => {
   const mocks = {
     $store: {
       getters: {
@@ -19,22 +20,32 @@ describe("Components > Wallet > Delegate", () => {
         },
       },
     },
-  };
+  }
 
+  return mount(
+    WalletDelegate,
+    merge(
+      {
+        i18n,
+        localVue,
+        mixins,
+        mocks,
+        stubs: {
+          RouterLinkStub,
+          WalletVoters: "<div></div>",
+        },
+        propsData: {
+          wallet: { publicKey: "02b1d2ea7c265db66087789f571fceb8cc2b2d89e296ad966efb8ed51855f2ae0b" },
+        },
+      },
+      config
+    ),
+  );
+};
+
+describe("Components > Wallet > Delegate", () => {
   it("should show the delegate info", () => {
-    const wrapper = mount(WalletDelegate, {
-      i18n,
-      localVue,
-      mixins,
-      mocks,
-      stubs: {
-        RouterLinkStub,
-        WalletVoters: "<div></div>",
-      },
-      propsData: {
-        wallet: { publicKey: "02b1d2ea7c265db66087789f571fceb8cc2b2d89e296ad966efb8ed51855f2ae0b" },
-      },
-    });
+    const wrapper = mountComponent();
 
     let divs = wrapper.findAll("div.list-row-border-b");
     expect(divs).toHaveLength(5);
@@ -47,5 +58,38 @@ describe("Components > Wallet > Delegate", () => {
     divs = wrapper.findAll("div.list-row");
     expect(divs).toHaveLength(1);
     expect(divs.at(0).text()).toBe("Forged blocks");
+  });
+
+  it('should render class "text-status-not-forging" and text "Resigned" when isResigned is true', () => {
+    const customProps = {
+      propsData: {
+        wallet: {
+          isResigned: true
+        }
+      }
+    };
+    const wrapper = mountComponent(customProps);
+    const element = wrapper.find('.text-status-not-forging');
+    expect(element.exists()).toBe(true);
+    expect(element.text()).toEqual('Resigned');
+  })
+
+  it('should render class "text-status-forging" and text "Active" when delegate rank is less or equal activeDelegates', () => {
+    const customMocks = {
+      $store: {
+        getters: {
+          "delegates/byPublicKey": publicKey => {
+            return { username: "", rank: 10 };
+          },
+          "network/activeDelegates": 11
+        },
+      },
+    };
+
+    const wrapper = mountComponent({ mocks: customMocks });
+    const element = wrapper.find('.text-status-forging');
+
+    expect(element.exists()).toBe(true);
+    expect(element.text()).toEqual('Active')
   });
 });


### PR DESCRIPTION
Adds 100% coverage for component `wallet/Delegate.vue` 
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

before:
![image](https://user-images.githubusercontent.com/10675595/98315259-98067100-1fb6-11eb-84fb-34ce11f226a5.png)

after: 
![image](https://user-images.githubusercontent.com/10675595/98315149-537ad580-1fb6-11eb-9f5c-b5daac04f194.png)

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
